### PR TITLE
fix: обеспечить использование заглушек в профиле по умолчанию

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -637,15 +637,6 @@
             </build>
         </profile>
         <profile>
-            <id>stubs</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            <properties>
-                <tests.micronaut.environments>local-no-docker</tests.micronaut.environments>
-            </properties>
-        </profile>
-        <profile>
             <id>it-external</id>
             <properties>
                 <tests.micronaut.environments>integration</tests.micronaut.environments>

--- a/src/main/java/ru/aritmos/config/LocalNoDockerDataBusClientStub.java
+++ b/src/main/java/ru/aritmos/config/LocalNoDockerDataBusClientStub.java
@@ -1,8 +1,10 @@
 package ru.aritmos.config;
 
-import io.micronaut.context.annotation.Replaces;
 import io.micronaut.context.annotation.Requires;
 import jakarta.inject.Singleton;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Mono;
@@ -13,8 +15,11 @@ import ru.aritmos.events.clients.DataBusClient;
  */
 @Singleton
 @Requires(env = "local-no-docker")
-@Replaces(DataBusClient.class)
 public class LocalNoDockerDataBusClientStub implements DataBusClient {
+
+  /** Хранит историю вызовов для проверки в тестах. */
+  private final List<InvocationRecord> invocations =
+      Collections.synchronizedList(new ArrayList<>());
 
   /**
    * Эмулирует отправку события без фактического HTTP-запроса.
@@ -35,8 +40,31 @@ public class LocalNoDockerDataBusClientStub implements DataBusClient {
       String senderService,
       String type,
       Object body) {
+    invocations.add(
+        new InvocationRecord(
+            destinationServices, sendToOtherBus, sendDate, senderService, type, body));
     // Просто подтверждаем отправку без реального HTTP вызова
     return Mono.just(Map.of("status", "stubbed", "type", type));
   }
-}
 
+  /** Возвращает копию записанных вызовов. */
+  public List<InvocationRecord> getInvocations() {
+    return List.copyOf(invocations);
+  }
+
+  /** Очищает историю вызовов. */
+  public void clearInvocations() {
+    invocations.clear();
+  }
+
+  /**
+   * Запись одного вызова {@link #send(String, Boolean, String, String, String, Object)}.
+   */
+  public record InvocationRecord(
+      String destinationServices,
+      Boolean sendToOtherBus,
+      String sendDate,
+      String senderService,
+      String type,
+      Object body) {}
+}

--- a/src/main/java/ru/aritmos/config/LocalNoDockerKeycloakStub.java
+++ b/src/main/java/ru/aritmos/config/LocalNoDockerKeycloakStub.java
@@ -1,6 +1,5 @@
 package ru.aritmos.config;
 
-import io.micronaut.context.annotation.Replaces;
 import io.micronaut.context.annotation.Requires;
 import jakarta.inject.Singleton;
 import java.util.ArrayList;
@@ -17,7 +16,6 @@ import ru.aritmos.keycloack.service.KeyCloackClient;
  */
 @Singleton
 @Requires(env = "local-no-docker")
-@Replaces(KeyCloackClient.class)
 public class LocalNoDockerKeycloakStub extends KeyCloackClient {
 
   /**

--- a/src/main/java/ru/aritmos/events/clients/DataBusClient.java
+++ b/src/main/java/ru/aritmos/events/clients/DataBusClient.java
@@ -1,5 +1,6 @@
 package ru.aritmos.events.clients;
 
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.async.annotation.SingleResult;
 import io.micronaut.http.annotation.Body;
 import io.micronaut.http.annotation.Header;
@@ -17,6 +18,7 @@ import org.reactivestreams.Publisher;
 /**
  * HTTP‑клиент для отправки событий на DataBus.
  */
+@Requires(notEnv = "local-no-docker")
 @Client(value = "${micronaut.application.dataBusUrl}")
 public interface DataBusClient {
   /**

--- a/src/main/java/ru/aritmos/events/services/KafkaListener.java
+++ b/src/main/java/ru/aritmos/events/services/KafkaListener.java
@@ -3,7 +3,6 @@ package ru.aritmos.events.services;
 import io.micronaut.configuration.kafka.annotation.KafkaKey;
 import io.micronaut.configuration.kafka.annotation.OffsetReset;
 import io.micronaut.configuration.kafka.annotation.Topic;
-import io.micronaut.context.annotation.Requires;
 import io.micronaut.scheduling.TaskExecutors;
 import io.micronaut.scheduling.annotation.ExecuteOn;
 import io.micronaut.serde.ObjectMapper;
@@ -19,7 +18,6 @@ import ru.aritmos.exceptions.SystemException;
  * Подписчик Kafka для обработки событий шины данных.
  */
 @Slf4j
-@Requires(notEnv = "local-no-docker")
 @io.micronaut.configuration.kafka.annotation.KafkaListener(offsetReset = OffsetReset.LATEST)
 public class KafkaListener {
   /** Обработчики общих событий (topic `events`). */

--- a/src/main/java/ru/aritmos/keycloack/service/KeyCloackClient.java
+++ b/src/main/java/ru/aritmos/keycloack/service/KeyCloackClient.java
@@ -1,6 +1,7 @@
 package ru.aritmos.keycloack.service;
 
 import io.micronaut.context.annotation.Property;
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.http.HttpStatus;
 import io.micronaut.http.annotation.*;
 import jakarta.inject.Inject;
@@ -32,6 +33,7 @@ import ru.aritmos.model.UserToken;
  */
 @Slf4j
 @Singleton
+@Requires(notEnv = "local-no-docker")
 @SuppressWarnings("all")
 public class KeyCloackClient {
   /** Сервис отправки событий. */


### PR DESCRIPTION
## Summary
- удалил профиль Maven `stubs` и активировал окружение `local-no-docker` по умолчанию
- отключил реальные клиенты DataBus и Keycloak в локальном окружении, добавил состояние в заглушку DataBus и убрал ограничение окружений у KafkaListener
- переписал EventServiceTest на использование истории вызовов заглушки вместо моков

## Testing
- `mvn -s .mvn/settings.xml test`


------
https://chatgpt.com/codex/tasks/task_e_68cc5983aae48328bf525aee78f6232a