### PR TITLE
test: добавляем проверки для автодовызова и конфигурации

### DIFF
--- a/src/test/unit/java/ru/aritmos/model/BranchConfigurationOperationsTest.java
+++ b/src/test/unit/java/ru/aritmos/model/BranchConfigurationOperationsTest.java
@@ -1,0 +1,198 @@
+package ru.aritmos.model;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static ru.aritmos.test.LoggingAssertions.*;
+
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.exceptions.HttpStatusException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import ru.aritmos.events.model.Event;
+import ru.aritmos.events.services.EventService;
+import ru.aritmos.model.visit.Visit;
+import ru.aritmos.model.User;
+import ru.aritmos.service.BranchService;
+import ru.aritmos.service.VisitService;
+import ru.aritmos.test.TestLoggingExtension;
+
+/**
+ * Дополнительные проверки конфигурационных операций {@link Branch}.
+ */
+@Slf4j
+@ExtendWith(TestLoggingExtension.class)
+class BranchConfigurationOperationsTest {
+
+    @Test
+    void updateVisitWithCustomActionPlacesEntitiesAndSendsEvents() {
+        log.info("Формируем отделение с очередью, пулом точек и сотрудниками");
+        Branch branch = new Branch("b-config", "Отделение конфигурации");
+
+        Queue queue = new Queue("queue-main", "Основная очередь", "A", 1);
+        Visit queueVisitHead = Visit.builder().id("visit-head").build();
+        Visit queueVisitTail = Visit.builder().id("visit-tail").build();
+        queue.getVisits().addAll(List.of(queueVisitHead, queueVisitTail));
+        branch.getQueues().put(queue.getId(), queue);
+
+        ServicePoint mainPoint = new ServicePoint("sp-main", "Основная точка");
+        Visit legacyVisit = Visit.builder().id("legacy").build();
+        mainPoint.setVisit(legacyVisit);
+        branch.getServicePoints().put(mainPoint.getId(), mainPoint);
+
+        ServicePoint poolPoint = new ServicePoint("sp-pool", "Пул точки");
+        User poolPointUser = new User();
+        poolPointUser.setId("user-pool-point");
+        poolPointUser.setName("Сотрудник пула точки");
+        poolPoint.setUser(poolPointUser);
+        poolPoint.getVisits().add(Visit.builder().id("pool-existing").build());
+        branch.getServicePoints().put(poolPoint.getId(), poolPoint);
+
+        ServicePoint userPoolPoint = new ServicePoint("sp-user", "Пул сотрудника");
+        User poolUser = new User();
+        poolUser.setId("user-pool");
+        poolUser.setName("Сотрудник пула");
+        poolUser.getVisits().add(Visit.builder().id("user-existing").build());
+        userPoolPoint.setUser(poolUser);
+        branch.getServicePoints().put(userPoolPoint.getId(), userPoolPoint);
+
+        Visit visit = Visit.builder()
+                .id("visit-new")
+                .branchId(branch.getId())
+                .queueId(queue.getId())
+                .servicePointId(mainPoint.getId())
+                .poolServicePointId(poolPoint.getId())
+                .poolUserId(poolUser.getId())
+                .events(new ArrayList<>())
+                .visitEvents(new ArrayList<>())
+                .servedServices(new ArrayList<>())
+                .unservedServices(new ArrayList<>())
+                .build();
+
+        EventService eventService = mock(EventService.class);
+        VisitService visitService = mock(VisitService.class);
+        BranchService branchService = mock(BranchService.class);
+        when(visitService.getBranchService()).thenReturn(branchService);
+
+        log.info("Вызываем updateVisit с произвольным действием");
+        branch.updateVisit(visit, eventService, "CUSTOM_ACTION", visitService);
+
+        assertSame(visit, branch.getServicePoints().get(mainPoint.getId()).getVisit());
+        assertEquals(List.of(queueVisitHead.getId(), queueVisitTail.getId(), visit.getId()),
+                branch.getQueues().get(queue.getId()).getVisits().stream().map(Visit::getId).toList());
+        assertTrue(poolPointUser.getVisits().contains(visit));
+        assertTrue(poolUser.getVisits().contains(visit));
+
+        verify(branchService).add(branch.getId(), branch);
+        ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
+        verify(eventService, times(2)).send(anyString(), eq(false), eventCaptor.capture());
+        List<Event> events = eventCaptor.getAllValues();
+        assertEquals("VISIT_CUSTOM_ACTION", events.get(0).getEventType());
+        assertEquals("VISIT_CUSTOM_ACTION", events.get(1).getEventType());
+        assertEquals(visit.getId(), ((Visit) events.get(0).getBody()).getId());
+    }
+
+    @Test
+    void updateVisitWithCustomActionThrowsWhenPointBusy() {
+        log.info("Готовим отделение с занятой точкой обслуживания");
+        Branch branch = new Branch("b-config", "Отделение конфигурации");
+        ServicePoint servicePoint = new ServicePoint("sp-main", "Основная точка") {
+            @Override
+            public void setVisit(Visit newVisit) {
+                if (newVisit != null) {
+                    super.setVisit(newVisit);
+                }
+            }
+        };
+        servicePoint.setVisit(Visit.builder().id("busy").build());
+        branch.getServicePoints().put(servicePoint.getId(), servicePoint);
+
+        Visit visit = Visit.builder()
+                .id("visit-new")
+                .servicePointId(servicePoint.getId())
+                .build();
+
+        EventService eventService = mock(EventService.class);
+        VisitService visitService = mock(VisitService.class);
+        BranchService branchService = mock(BranchService.class);
+        when(visitService.getBranchService()).thenReturn(branchService);
+
+        log.info("Пытаемся обновить визит — ожидаем конфликт");
+        HttpStatusException exception = assertThrows(HttpStatusException.class,
+                () -> branch.updateVisit(visit, eventService, "CUSTOM_ACTION", visitService));
+        assertEquals(HttpStatus.CONFLICT, exception.getStatus());
+    }
+
+    @Test
+    void addUpdateServicePointRestoresStateAndPublishesEvents() {
+        log.info("Настраиваем отделение с существующей точкой и назначенным визитом");
+        Branch branch = new Branch("b-service-point", "Отделение с точками");
+        ServicePoint existing = new ServicePoint("sp-existing", "Точка с визитом");
+        Visit visit = Visit.builder().id("visit-existing").build();
+        existing.setVisit(visit);
+        User staff = new User();
+        staff.setId("staff-existing");
+        staff.setName("Анна Сотрудник");
+        existing.setUser(staff);
+        branch.getServicePoints().put(existing.getId(), existing);
+
+        ServicePoint updated = new ServicePoint(existing.getId(), "Обновлённая точка");
+        ServicePoint newcomer = new ServicePoint("sp-new", "Новая точка");
+        HashMap<String, ServicePoint> payload = new HashMap<>();
+        payload.put(existing.getId(), updated);
+        payload.put(newcomer.getId(), newcomer);
+
+        EventService eventService = mock(EventService.class);
+
+        log.info("Обновляем конфигурацию точек с восстановлением визита и сотрудника");
+        branch.addUpdateServicePoint(payload, true, true, eventService);
+
+        ServicePoint restored = branch.getServicePoints().get(existing.getId());
+        assertSame(visit, restored.getVisit());
+        assertSame(staff, restored.getUser());
+        assertSame(newcomer, branch.getServicePoints().get(newcomer.getId()));
+
+        verify(eventService).sendChangedEvent(eq("config"), eq(false), eq(existing), eq(updated), anyMap(), eq("Update service point"));
+        verify(eventService).sendChangedEvent(eq("config"), eq(false), isNull(), eq(newcomer), anyMap(), eq("Add service point"));
+    }
+
+    @Test
+    void addUpdateQueuesRestoresVisitsAndNotifiesConsumers() {
+        log.info("Готовим отделение с очередями и точкой обслуживания");
+        Branch branch = new Branch("b-queues", "Очередное отделение");
+        Queue existingQueue = new Queue("queue-existing", "Старая очередь", "A", 5);
+        existingQueue.getVisits().add(Visit.builder().id("v-old").build());
+        existingQueue.setTicketCounter(42);
+        branch.getQueues().put(existingQueue.getId(), existingQueue);
+        ServicePoint mirroredPoint = new ServicePoint(existingQueue.getId(), "Связанная точка");
+        branch.getServicePoints().put(mirroredPoint.getId(), mirroredPoint);
+
+        Queue updatedQueue = new Queue(existingQueue.getId(), "Обновлённая очередь", "A", 5);
+        Queue newQueue = new Queue("queue-new", "Новая очередь", "B", 3);
+        HashMap<String, Queue> payload = new HashMap<>();
+        payload.put(existingQueue.getId(), updatedQueue);
+        payload.put(newQueue.getId(), newQueue);
+
+        EventService eventService = mock(EventService.class);
+
+        log.info("Обновляем набор очередей с восстановлением списка визитов");
+        branch.addUpdateQueues(payload, true, eventService);
+
+        Queue restoredQueue = branch.getQueues().get(existingQueue.getId());
+        assertSame(updatedQueue, restoredQueue);
+        assertEquals(42, restoredQueue.getTicketCounter());
+        assertEquals(existingQueue.getVisits().stream().map(Visit::getId).toList(),
+                restoredQueue.getVisits().stream().map(Visit::getId).toList());
+        assertSame(newQueue, branch.getQueues().get(newQueue.getId()));
+
+        verify(eventService).sendChangedEvent(eq("config"), eq(false), eq(existingQueue), eq(updatedQueue), anyMap(), eq("Update queue"));
+        verify(eventService).sendChangedEvent(eq("config"), eq(false), eq(mirroredPoint), eq(updatedQueue), anyMap(), eq("Update service"));
+        verify(eventService).sendChangedEvent(eq("config"), eq(false), isNull(), eq(newQueue), anyMap(), eq("Add queue"));
+        verify(eventService).sendChangedEvent(eq("config"), eq(false), isNull(), eq(newQueue), anyMap(), eq("Add service"));
+    }
+}

--- a/src/test/unit/java/ru/aritmos/service/VisitServiceMaxCallRulesTest.java
+++ b/src/test/unit/java/ru/aritmos/service/VisitServiceMaxCallRulesTest.java
@@ -1,0 +1,473 @@
+package ru.aritmos.service;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static ru.aritmos.test.LoggingAssertions.*;
+
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.exceptions.HttpStatusException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import ru.aritmos.events.model.Event;
+import ru.aritmos.events.services.EventService;
+import ru.aritmos.model.Branch;
+import ru.aritmos.model.ServicePoint;
+import ru.aritmos.model.User;
+import ru.aritmos.model.visit.Visit;
+import ru.aritmos.service.rules.CallRule;
+import ru.aritmos.test.TestLoggingExtension;
+
+/**
+ * Тесты максимальных стратегий вызова визитов {@link VisitService}.
+ */
+@Slf4j
+@ExtendWith(TestLoggingExtension.class)
+class VisitServiceMaxCallRulesTest {
+
+    @Test
+    void visitCallWithMaximalWaitingTimeUsesRuleResult() {
+        log.info("Готовим отделение и точку обслуживания с оператором для сценария максимального ожидания");
+        Branch branch = new Branch("b-max-wait", "Главное отделение");
+        ServicePoint servicePoint = new ServicePoint("sp-main", "Окно №1");
+        User operator = new User();
+        operator.setId("staff-001");
+        operator.setName("Иван Оператор");
+        operator.setCurrentWorkProfileId("wp-main");
+        servicePoint.setUser(operator);
+        branch.getServicePoints().put(servicePoint.getId(), servicePoint);
+
+        Visit waitingVisit = Visit.builder()
+                .id("visit-wait")
+                .branchId(branch.getId())
+                .parameterMap(new HashMap<>())
+                .build();
+        Visit limitedQueueVisit = Visit.builder()
+                .id("visit-queue")
+                .branchId(branch.getId())
+                .parameterMap(new HashMap<>())
+                .build();
+
+        BranchService branchService = mock(BranchService.class);
+        when(branchService.getBranch(branch.getId())).thenReturn(branch);
+        EventService eventService = mock(EventService.class);
+        CallRule waitingRule = mock(CallRule.class);
+        CallRule lifeRule = mock(CallRule.class);
+        when(waitingRule.call(branch, servicePoint)).thenReturn(Optional.of(waitingVisit));
+        List<String> queueIds = List.of("q-1", "q-2");
+        when(waitingRule.call(branch, servicePoint, queueIds)).thenReturn(Optional.of(limitedQueueVisit));
+
+        VisitService service = spy(new VisitService());
+        service.branchService = branchService;
+        service.eventService = eventService;
+        service.waitingTimeCallRule = waitingRule;
+        service.lifeTimeCallRule = lifeRule;
+        doAnswer(invocation -> Optional.of(invocation.getArgument(2)))
+                .when(service)
+                .visitCall(anyString(), anyString(), any(Visit.class), anyString());
+
+        log.info("Запускаем вызов без ограничения очередей");
+        Optional<Visit> firstResult = service.visitCallWithMaximalWaitingTime(branch.getId(), servicePoint.getId());
+        assertTrue(firstResult::isPresent, "Ожидаем, что правило вернуло кандидата на вызов");
+        assertSame(waitingVisit, firstResult.orElseThrow());
+
+        log.info("Повторяем вызов с ограничением по списку очередей {}", queueIds);
+        Optional<Visit> secondResult = service.visitCallWithMaximalWaitingTime(branch.getId(), servicePoint.getId(), queueIds);
+        assertTrue(secondResult::isPresent, "Визит из ограниченного набора должен быть найден");
+        assertSame(limitedQueueVisit, secondResult.orElseThrow());
+
+        verify(waitingRule).call(branch, servicePoint);
+        verify(waitingRule).call(branch, servicePoint, queueIds);
+        verify(service, times(2)).visitCall(eq(branch.getId()), eq(servicePoint.getId()), any(Visit.class), eq("callNext"));
+    }
+
+    @Test
+    void visitCallWithMaximalWaitingTimeEnablesAutocallWhenRuleReturnsEmpty() {
+        log.info("Настраиваем отделение в режиме авто-вызова для проверки перехода в автодовызов");
+        Branch branch = new Branch("b-auto-wait", "Отделение с авто-вызовом");
+        branch.getParameterMap().put("autoCallMode", true);
+        ServicePoint servicePoint = new ServicePoint("sp-auto", "Авто окно");
+        User operator = new User();
+        operator.setId("staff-777");
+        operator.setName("Пётр Автовызов");
+        operator.setCurrentWorkProfileId("wp-auto");
+        servicePoint.setUser(operator);
+        branch.getServicePoints().put(servicePoint.getId(), servicePoint);
+
+        BranchService branchService = mock(BranchService.class);
+        when(branchService.getBranch(branch.getId())).thenReturn(branch);
+        EventService eventService = mock(EventService.class);
+        CallRule waitingRule = mock(CallRule.class);
+        when(waitingRule.call(branch, servicePoint)).thenReturn(Optional.empty());
+        List<String> queueIds = List.of("priority-1");
+        when(waitingRule.call(branch, servicePoint, queueIds)).thenReturn(Optional.empty());
+
+        VisitService service = new VisitService();
+        service.branchService = branchService;
+        service.eventService = eventService;
+        service.waitingTimeCallRule = waitingRule;
+        service.lifeTimeCallRule = mock(CallRule.class);
+
+        log.info("Запускаем вызов без очередных ограничений: ожидаем исключение со статусом 207");
+        HttpStatusException firstException = assertThrows(
+                HttpStatusException.class,
+                () -> service.visitCallWithMaximalWaitingTime(branch.getId(), servicePoint.getId()));
+        assertEquals(HttpStatus.MULTI_STATUS, firstException.getStatus());
+        assertTrue(servicePoint.getAutoCallMode(), "Флаг автодовызова должен включиться после первой попытки");
+
+        log.info("Повторно запускаем сценарий для варианта с конкретным набором очередей {}", queueIds);
+        servicePoint.setAutoCallMode(false);
+        HttpStatusException secondException = assertThrows(
+                HttpStatusException.class,
+                () -> service.visitCallWithMaximalWaitingTime(branch.getId(), servicePoint.getId(), queueIds));
+        assertEquals(HttpStatus.MULTI_STATUS, secondException.getStatus());
+        assertTrue(servicePoint.getAutoCallMode(), "Флаг автодовызова должен включиться и во втором сценарии");
+
+        ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
+        verify(eventService, times(2)).send(eq("frontend"), eq(false), eventCaptor.capture());
+        for (Event event : eventCaptor.getAllValues()) {
+            assertEquals("SERVICEPOINT_AUTOCALL_MODE_TURN_ON", event.getEventType());
+            Map<String, String> params = event.getParams();
+            assertEquals(branch.getId(), params.get("branchId"));
+            assertEquals(servicePoint.getId(), params.get("servicePointId"));
+            assertSame(servicePoint, event.getBody());
+        }
+        verify(branchService, times(2)).add(branch.getId(), branch);
+    }
+
+    @Test
+    void visitCallWithMaximalWaitingTimeFailsWhenServicePointMissing() {
+        log.info("Проверяем сценарий, когда точка обслуживания отсутствует в конфигурации отделения");
+        Branch branch = new Branch("b-missing-wait", "Отделение без точки");
+
+        BranchService branchService = mock(BranchService.class);
+        when(branchService.getBranch(branch.getId())).thenReturn(branch);
+        VisitService service = new VisitService();
+        service.branchService = branchService;
+        service.eventService = mock(EventService.class);
+        service.waitingTimeCallRule = mock(CallRule.class);
+        service.lifeTimeCallRule = mock(CallRule.class);
+
+        log.info("Вызываем метод без ограничений очередей и ожидаем ошибку 404");
+        HttpStatusException first = assertThrows(HttpStatusException.class,
+                () -> service.visitCallWithMaximalWaitingTime(branch.getId(), "absent"));
+        assertEquals(HttpStatus.NOT_FOUND, first.getStatus());
+
+        log.info("Повторяем вызов для варианта со списком очередей");
+        HttpStatusException second = assertThrows(HttpStatusException.class,
+                () -> service.visitCallWithMaximalWaitingTime(branch.getId(), "absent", List.of("q1")));
+        assertEquals(HttpStatus.NOT_FOUND, second.getStatus());
+    }
+
+    @Test
+    void visitCallWithMaxLifeTimeFailsWhenServicePointMissing() {
+        log.info("Конфигурация отделения не содержит точку обслуживания, ожидаем ошибку при вызове по времени жизни");
+        Branch branch = new Branch("b-missing-life", "Отделение без точек");
+
+        BranchService branchService = mock(BranchService.class);
+        when(branchService.getBranch(branch.getId())).thenReturn(branch);
+        VisitService service = new VisitService();
+        service.branchService = branchService;
+        service.eventService = mock(EventService.class);
+        service.lifeTimeCallRule = mock(CallRule.class);
+        service.waitingTimeCallRule = mock(CallRule.class);
+
+        log.info("Запрос без списка очередей приводит к 404");
+        HttpStatusException first = assertThrows(HttpStatusException.class,
+                () -> service.visitCallWithMaxLifeTime(branch.getId(), "missing"));
+        assertEquals(HttpStatus.NOT_FOUND, first.getStatus());
+
+        log.info("Проверяем поведение для варианта со списком очередей");
+        HttpStatusException second = assertThrows(HttpStatusException.class,
+                () -> service.visitCallWithMaxLifeTime(branch.getId(), "missing", List.of("q1")));
+        assertEquals(HttpStatus.NOT_FOUND, second.getStatus());
+    }
+
+    @Test
+    void visitCallWithMaximalWaitingTimeFailsWhenUserNotLogged() {
+        log.info("Создаём точку обслуживания без оператора и проверяем реакцию метода");
+        Branch branch = new Branch("b-no-user", "Отделение без оператора");
+        ServicePoint servicePoint = new ServicePoint("sp-free", "Свободная точка");
+        branch.getServicePoints().put(servicePoint.getId(), servicePoint);
+
+        BranchService branchService = mock(BranchService.class);
+        when(branchService.getBranch(branch.getId())).thenReturn(branch);
+        VisitService service = new VisitService();
+        service.branchService = branchService;
+        service.eventService = mock(EventService.class);
+        service.waitingTimeCallRule = mock(CallRule.class);
+        service.lifeTimeCallRule = mock(CallRule.class);
+
+        log.info("Метод должен вернуть 403 при отсутствии оператора");
+        HttpStatusException first = assertThrows(HttpStatusException.class,
+                () -> service.visitCallWithMaximalWaitingTime(branch.getId(), servicePoint.getId()));
+        assertEquals(HttpStatus.FORBIDDEN, first.getStatus());
+
+        log.info("Проверяем ту же ситуацию для варианта со списком очередей");
+        HttpStatusException second = assertThrows(HttpStatusException.class,
+                () -> service.visitCallWithMaximalWaitingTime(branch.getId(), servicePoint.getId(), List.of("q1")));
+        assertEquals(HttpStatus.FORBIDDEN, second.getStatus());
+    }
+
+    @Test
+    void visitCallWithMaxLifeTimeFailsWhenUserNotLogged() {
+        log.info("Имитация точки без оператора для правила по времени жизни");
+        Branch branch = new Branch("b-no-user-life", "Отделение без оператора");
+        ServicePoint servicePoint = new ServicePoint("sp-free-life", "Свободная точка");
+        branch.getServicePoints().put(servicePoint.getId(), servicePoint);
+
+        BranchService branchService = mock(BranchService.class);
+        when(branchService.getBranch(branch.getId())).thenReturn(branch);
+        VisitService service = new VisitService();
+        service.branchService = branchService;
+        service.eventService = mock(EventService.class);
+        service.lifeTimeCallRule = mock(CallRule.class);
+        service.waitingTimeCallRule = mock(CallRule.class);
+
+        log.info("Основной метод должен вернуть 403");
+        HttpStatusException first = assertThrows(HttpStatusException.class,
+                () -> service.visitCallWithMaxLifeTime(branch.getId(), servicePoint.getId()));
+        assertEquals(HttpStatus.FORBIDDEN, first.getStatus());
+
+        log.info("Аналогичный результат ожидается и при указании списка очередей");
+        HttpStatusException second = assertThrows(HttpStatusException.class,
+                () -> service.visitCallWithMaxLifeTime(branch.getId(), servicePoint.getId(), List.of("q2")));
+        assertEquals(HttpStatus.FORBIDDEN, second.getStatus());
+    }
+
+    @Test
+    void visitCallWithMaximalWaitingTimeReturnsEmptyWhenNoAutoCallConfigured() {
+        log.info("Готовим отделение без режима автодовызова и ожидаем пустой результат");
+        Branch branch = new Branch("b-no-autocall", "Обычное отделение");
+        ServicePoint servicePoint = new ServicePoint("sp-regular", "Рабочее окно");
+        User operator = new User();
+        operator.setId("staff-regular");
+        operator.setName("Иван Рабочий");
+        servicePoint.setUser(operator);
+        branch.getServicePoints().put(servicePoint.getId(), servicePoint);
+
+        BranchService branchService = mock(BranchService.class);
+        when(branchService.getBranch(branch.getId())).thenReturn(branch);
+        EventService eventService = mock(EventService.class);
+        CallRule waitingRule = mock(CallRule.class);
+        when(waitingRule.call(branch, servicePoint)).thenReturn(Optional.empty());
+        when(waitingRule.call(branch, servicePoint, List.of("q-empty"))).thenReturn(Optional.empty());
+
+        VisitService service = new VisitService();
+        service.branchService = branchService;
+        service.eventService = eventService;
+        service.waitingTimeCallRule = waitingRule;
+        service.lifeTimeCallRule = mock(CallRule.class);
+
+        log.info("Без списка очередей метод возвращает пустой результат");
+        Optional<Visit> direct = service.visitCallWithMaximalWaitingTime(branch.getId(), servicePoint.getId());
+        assertTrue(direct::isEmpty);
+
+        log.info("С ограничением по очереди поведение аналогично");
+        Optional<Visit> limited = service.visitCallWithMaximalWaitingTime(branch.getId(), servicePoint.getId(), List.of("q-empty"));
+        assertTrue(limited::isEmpty);
+
+        verify(eventService, never()).send(anyString(), anyBoolean(), any(Event.class));
+    }
+
+    @Test
+    void visitCallWithMaxLifeTimeReturnsEmptyWhenNoAutoCallConfigured() {
+        log.info("Отделение без автодовызова должно возвращать пустой результат при отсутствии кандидатов по времени жизни");
+        Branch branch = new Branch("b-no-autocall-life", "Обычное отделение");
+        ServicePoint servicePoint = new ServicePoint("sp-life-regular", "Рабочее окно");
+        User operator = new User();
+        operator.setId("staff-life-regular");
+        operator.setName("Мария Рабочая");
+        servicePoint.setUser(operator);
+        branch.getServicePoints().put(servicePoint.getId(), servicePoint);
+
+        BranchService branchService = mock(BranchService.class);
+        when(branchService.getBranch(branch.getId())).thenReturn(branch);
+        EventService eventService = mock(EventService.class);
+        CallRule lifeRule = mock(CallRule.class);
+        when(lifeRule.call(branch, servicePoint)).thenReturn(Optional.empty());
+        when(lifeRule.call(branch, servicePoint, List.of("life-empty"))).thenReturn(Optional.empty());
+
+        VisitService service = new VisitService();
+        service.branchService = branchService;
+        service.eventService = eventService;
+        service.lifeTimeCallRule = lifeRule;
+        service.waitingTimeCallRule = mock(CallRule.class);
+
+        log.info("Проверяем сценарий без списка очередей");
+        Optional<Visit> direct = service.visitCallWithMaxLifeTime(branch.getId(), servicePoint.getId());
+        assertTrue(direct::isEmpty);
+
+        log.info("С ограничением по очередям результат также пустой");
+        Optional<Visit> limited = service.visitCallWithMaxLifeTime(branch.getId(), servicePoint.getId(), List.of("life-empty"));
+        assertTrue(limited::isEmpty);
+
+        verify(eventService, never()).send(anyString(), anyBoolean(), any(Event.class));
+    }
+
+    @Test
+    void visitCallWithMaxLifeTimeUsesRuleResult() {
+        log.info("Готовим отделение для сценария вызова по максимальному времени жизни визита");
+        Branch branch = new Branch("b-max-life", "Отделение по времени жизни");
+        ServicePoint servicePoint = new ServicePoint("sp-life", "Окно времени жизни");
+        User operator = new User();
+        operator.setId("staff-life");
+        operator.setName("Мария Жизненная");
+        operator.setCurrentWorkProfileId("wp-life");
+        servicePoint.setUser(operator);
+        branch.getServicePoints().put(servicePoint.getId(), servicePoint);
+
+        Visit lifeTimeCandidate = Visit.builder()
+                .id("visit-life")
+                .branchId(branch.getId())
+                .parameterMap(new HashMap<>())
+                .build();
+        Visit limitedLifeCandidate = Visit.builder()
+                .id("visit-life-queue")
+                .branchId(branch.getId())
+                .parameterMap(new HashMap<>())
+                .build();
+        List<String> queueIds = List.of("life-1", "life-2");
+
+        BranchService branchService = mock(BranchService.class);
+        when(branchService.getBranch(branch.getId())).thenReturn(branch);
+        EventService eventService = mock(EventService.class);
+        CallRule lifeRule = mock(CallRule.class);
+        CallRule waitingRule = mock(CallRule.class);
+        when(lifeRule.call(branch, servicePoint)).thenReturn(Optional.of(lifeTimeCandidate));
+        when(lifeRule.call(branch, servicePoint, queueIds)).thenReturn(Optional.of(limitedLifeCandidate));
+
+        VisitService service = spy(new VisitService());
+        service.branchService = branchService;
+        service.eventService = eventService;
+        service.lifeTimeCallRule = lifeRule;
+        service.waitingTimeCallRule = waitingRule;
+        doAnswer(invocation -> Optional.of(invocation.getArgument(2)))
+                .when(service)
+                .visitCall(anyString(), anyString(), any(Visit.class), anyString());
+
+        log.info("Запускаем вызов по максимальному времени жизни без ограничений очередей");
+        Optional<Visit> firstResult = service.visitCallWithMaxLifeTime(branch.getId(), servicePoint.getId());
+        assertTrue(firstResult::isPresent, "Правило максимального времени жизни должно вернуть визит");
+        assertSame(lifeTimeCandidate, firstResult.orElseThrow());
+
+        log.info("Проверяем сценарий с ограниченным набором очередей {}");
+        Optional<Visit> secondResult = service.visitCallWithMaxLifeTime(branch.getId(), servicePoint.getId(), queueIds);
+        assertTrue(secondResult::isPresent, "Из выбранных очередей также должен быть выбран визит");
+        assertSame(limitedLifeCandidate, secondResult.orElseThrow());
+
+        verify(lifeRule).call(branch, servicePoint);
+        verify(lifeRule).call(branch, servicePoint, queueIds);
+        verify(service, times(2)).visitCall(eq(branch.getId()), eq(servicePoint.getId()), any(Visit.class), eq("callNext"));
+    }
+
+    @Test
+    void visitCallWithMaxLifeTimeEnablesAutocallWhenRuleReturnsEmpty() {
+        log.info("Создаём отделение с авто-вызовом для проверки поведения правил по времени жизни");
+        Branch branch = new Branch("b-auto-life", "Авто отделение времени жизни");
+        branch.getParameterMap().put("autoCallMode", true);
+        ServicePoint servicePoint = new ServicePoint("sp-auto-life", "Авто окно времени жизни");
+        User operator = new User();
+        operator.setId("staff-auto-life");
+        operator.setName("Сергей Авто");
+        operator.setCurrentWorkProfileId("wp-auto-life");
+        servicePoint.setUser(operator);
+        branch.getServicePoints().put(servicePoint.getId(), servicePoint);
+
+        BranchService branchService = mock(BranchService.class);
+        when(branchService.getBranch(branch.getId())).thenReturn(branch);
+        EventService eventService = mock(EventService.class);
+        CallRule lifeRule = mock(CallRule.class);
+        CallRule waitingRule = mock(CallRule.class);
+        when(lifeRule.call(branch, servicePoint)).thenReturn(Optional.empty());
+        List<String> queueIds = List.of("ql-1");
+        when(lifeRule.call(branch, servicePoint, queueIds)).thenReturn(Optional.empty());
+
+        VisitService service = new VisitService();
+        service.branchService = branchService;
+        service.eventService = eventService;
+        service.lifeTimeCallRule = lifeRule;
+        service.waitingTimeCallRule = waitingRule;
+
+        log.info("Запускаем вызов без ограничений — ожидаем включение автодовызова");
+        HttpStatusException firstException = assertThrows(
+                HttpStatusException.class,
+                () -> service.visitCallWithMaxLifeTime(branch.getId(), servicePoint.getId()));
+        assertEquals(HttpStatus.MULTI_STATUS, firstException.getStatus());
+        assertTrue(servicePoint.getAutoCallMode(), "Автодовызов должен включиться после первого запроса");
+
+        log.info("Повторяем сценарий для конкретного списка очередей {}");
+        servicePoint.setAutoCallMode(false);
+        HttpStatusException secondException = assertThrows(
+                HttpStatusException.class,
+                () -> service.visitCallWithMaxLifeTime(branch.getId(), servicePoint.getId(), queueIds));
+        assertEquals(HttpStatus.MULTI_STATUS, secondException.getStatus());
+        assertTrue(servicePoint.getAutoCallMode(), "Автодовызов должен включиться и во втором случае");
+
+        ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
+        verify(eventService, times(2)).send(eq("frontend"), eq(false), eventCaptor.capture());
+        for (Event event : eventCaptor.getAllValues()) {
+            assertEquals("SERVICEPOINT_AUTOCALL_MODE_TURN_ON", event.getEventType());
+            Map<String, String> params = event.getParams();
+            assertEquals(branch.getId(), params.get("branchId"));
+            assertEquals(servicePoint.getId(), params.get("servicePointId"));
+            assertSame(servicePoint, event.getBody());
+        }
+        verify(branchService, times(2)).add(branch.getId(), branch);
+    }
+
+    @Test
+    void visitCallStrategiesDoNotTriggerAutocallForBusyServicePoint() {
+        log.info("Готовим отделение с точкой, на которой уже обслуживается визит");
+        Branch branch = new Branch("b-busy", "Отделение с занятым окном");
+        ServicePoint servicePoint = new ServicePoint("sp-busy", "Занятая точка");
+        User operator = new User();
+        operator.setId("staff-busy");
+        operator.setName("Галина Оператор");
+        servicePoint.setUser(operator);
+        servicePoint.setVisit(Visit.builder().id("active").branchId(branch.getId()).build());
+        branch.getServicePoints().put(servicePoint.getId(), servicePoint);
+        branch.getParameterMap().put("autoCallMode", true);
+
+        BranchService branchService = mock(BranchService.class);
+        when(branchService.getBranch(branch.getId())).thenReturn(branch);
+        EventService eventService = mock(EventService.class);
+        CallRule waitingRule = mock(CallRule.class);
+        CallRule lifeRule = mock(CallRule.class);
+        when(waitingRule.call(branch, servicePoint)).thenReturn(Optional.empty());
+        when(waitingRule.call(branch, servicePoint, List.of("q-special"))).thenReturn(Optional.empty());
+        when(lifeRule.call(branch, servicePoint)).thenReturn(Optional.empty());
+        when(lifeRule.call(branch, servicePoint, List.of("life-special"))).thenReturn(Optional.empty());
+
+        VisitService service = new VisitService();
+        service.branchService = branchService;
+        service.eventService = eventService;
+        service.waitingTimeCallRule = waitingRule;
+        service.lifeTimeCallRule = lifeRule;
+
+        log.info("Метод по времени ожидания должен вернуть пустой результат без изменения флагов");
+        Optional<Visit> waitResult = service.visitCallWithMaximalWaitingTime(branch.getId(), servicePoint.getId());
+        assertTrue(waitResult::isEmpty, "Визит не должен быть подобран");
+        assertFalse(Boolean.TRUE.equals(servicePoint.getAutoCallMode()));
+
+        log.info("Повторяем вызов для варианта со списком очередей");
+        Optional<Visit> waitLimited = service.visitCallWithMaximalWaitingTime(branch.getId(), servicePoint.getId(), List.of("q-special"));
+        assertTrue(waitLimited::isEmpty);
+        assertFalse(Boolean.TRUE.equals(servicePoint.getAutoCallMode()));
+
+        log.info("Проверяем методы по времени жизни визита");
+        Optional<Visit> lifeResult = service.visitCallWithMaxLifeTime(branch.getId(), servicePoint.getId());
+        assertTrue(lifeResult::isEmpty);
+        Optional<Visit> lifeLimited = service.visitCallWithMaxLifeTime(branch.getId(), servicePoint.getId(), List.of("life-special"));
+        assertTrue(lifeLimited::isEmpty);
+
+        verify(branchService, never()).add(anyString(), any());
+        verify(eventService, never()).send(anyString(), anyBoolean(), any(Event.class));
+    }
+
+}


### PR DESCRIPTION
## Резюме
- добавлены модульные тесты BranchConfigurationOperationsTest, покрывающие обновление визитов, точек обслуживания и очередей в отделении
- реализован широкий набор сценариев VisitServiceMaxCallRulesTest для стратегий вызова по ожиданию и времени жизни, включая исключительные случаи и работу автодовызова

## Тестирование
- mvn -s .mvn/settings.xml test

------
https://chatgpt.com/codex/tasks/task_e_68cd073eb21c832899a692246ecabfcf