### PR TITLE
fix: устраняю сетевые ошибки загрузки зависимостей

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,1 @@
+-Djava.net.preferIPv4Stack=true

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,5 @@
+-s=.mvn/settings.xml
+-Dmaven.proxy.active=true
+-Dmaven.proxy.host=proxy
+-Dmaven.proxy.port=8080
+-Dmaven.proxy.nonProxyHosts=localhost|127.0.0.1|::1

--- a/.mvn/settings.xml
+++ b/.mvn/settings.xml
@@ -4,19 +4,19 @@
   <proxies>
     <proxy>
       <id>default-http</id>
-      <active>true</active>
+      <active>${maven.proxy.active}</active>
       <protocol>http</protocol>
-      <host>proxy</host>
-      <port>8080</port>
-      <nonProxyHosts>localhost|127.0.0.1|::1</nonProxyHosts>
+      <host>${maven.proxy.host}</host>
+      <port>${maven.proxy.port}</port>
+      <nonProxyHosts>${maven.proxy.nonProxyHosts}</nonProxyHosts>
     </proxy>
     <proxy>
       <id>default-https</id>
-      <active>true</active>
+      <active>${maven.proxy.active}</active>
       <protocol>https</protocol>
-      <host>proxy</host>
-      <port>8080</port>
-      <nonProxyHosts>localhost|127.0.0.1|::1</nonProxyHosts>
+      <host>${maven.proxy.host}</host>
+      <port>${maven.proxy.port}</port>
+      <nonProxyHosts>${maven.proxy.nonProxyHosts}</nonProxyHosts>
     </proxy>
   </proxies>
 </settings>


### PR DESCRIPTION
## Что сделано
- Вынес параметры корпоративного прокси в свойства Maven и подключил их через `.mvn/settings.xml`, чтобы клиенты автоматически использовали корректный маршрут при скачивании зависимостей.
- Добавил `.mvn/maven.config` и `.mvn/jvm.config` для автоподстановки настроек прокси и принудительного использования IPv4.

## Связанный issue
- отсутствует

## План проверки
- `mvn -DskipTests package`

## Изменения конфигурации/переменных
- Новый `.mvn/maven.config` с дефолтными значениями `maven.proxy.*`, допускающими переопределение через параметры запуска.
- Новый `.mvn/jvm.config` с флагом `-Djava.net.preferIPv4Stack=true`.

## Потенциальные риски
- Низкие: при работе без прокси необходимо явно задать `-Dmaven.proxy.active=false`.

------
https://chatgpt.com/codex/tasks/task_e_68d3aeac5f2483288e247a3ff94aa7b6