### PR TITLE
fix: корректная локализация сообщений BusinessException

### DIFF
--- a/src/main/java/ru/aritmos/api/EntrypointController.java
+++ b/src/main/java/ru/aritmos/api/EntrypointController.java
@@ -112,7 +112,8 @@ public class EntrypointController {
     try {
       branch = branchService.getBranch(branchId);
     } catch (Exception ex) {
-      throw new BusinessException("Branch not found", eventService, HttpStatus.NOT_FOUND);
+      throw new BusinessException(
+          "Branch not found", "Отделение не найдено", eventService, HttpStatus.NOT_FOUND);
     }
     if (new HashSet<>(branch.getServices().values().stream().map(BranchEntity::getId).toList())
         .containsAll(serviceIds)) {
@@ -122,7 +123,8 @@ public class EntrypointController {
       return visitService.createVirtualVisit(branchId, servicePointId, visitParameters, sid);
 
     } else {
-      throw new BusinessException("Services not found", eventService, HttpStatus.NOT_FOUND);
+      throw new BusinessException(
+          "Services not found", "Услуги не найдены", eventService, HttpStatus.NOT_FOUND);
     }
   }
 
@@ -185,7 +187,8 @@ public class EntrypointController {
     try {
       branch = branchService.getBranch(branchId);
     } catch (Exception ex) {
-      throw new BusinessException("Branch not found", eventService, HttpStatus.NOT_FOUND);
+      throw new BusinessException(
+          "Branch not found", "Отделение не найдено", eventService, HttpStatus.NOT_FOUND);
     }
     if (new HashSet<>(branch.getServices().values().stream().map(BranchEntity::getId).toList())
         .containsAll(serviceIds)) {
@@ -200,7 +203,8 @@ public class EntrypointController {
       }
 
     } else {
-      throw new BusinessException("Services not found", eventService, HttpStatus.NOT_FOUND);
+      throw new BusinessException(
+          "Services not found", "Услуги не найдены", eventService, HttpStatus.NOT_FOUND);
     }
   }
 
@@ -274,7 +278,8 @@ public class EntrypointController {
     try {
       branch = branchService.getBranch(branchId);
     } catch (Exception ex) {
-      throw new BusinessException("Branch not found", eventService, HttpStatus.NOT_FOUND);
+      throw new BusinessException(
+          "Branch not found", "Отделение не найдено", eventService, HttpStatus.NOT_FOUND);
     }
     if (new HashSet<>(branch.getServices().values().stream().map(BranchEntity::getId).toList())
         .containsAll(parameters.getServiceIds())) {
@@ -286,7 +291,8 @@ public class EntrypointController {
       }
 
     } else {
-      throw new BusinessException("Services not found", eventService, HttpStatus.NOT_FOUND);
+      throw new BusinessException(
+          "Services not found", "Услуги не найдены", eventService, HttpStatus.NOT_FOUND);
     }
   }
 
@@ -361,7 +367,8 @@ public class EntrypointController {
     try {
       branch = branchService.getBranch(branchId);
     } catch (Exception ex) {
-      throw new BusinessException("Branch not found", eventService, HttpStatus.NOT_FOUND);
+      throw new BusinessException(
+          "Branch not found", "Отделение не найдено", eventService, HttpStatus.NOT_FOUND);
     }
     if (new HashSet<>(branch.getServices().values().stream().map(BranchEntity::getId).toList())
         .containsAll(parameters.getServiceIds())) {
@@ -374,7 +381,8 @@ public class EntrypointController {
       }
 
     } else {
-      throw new BusinessException("Services not found", eventService, HttpStatus.NOT_FOUND);
+      throw new BusinessException(
+          "Services not found", "Услуги не найдены", eventService, HttpStatus.NOT_FOUND);
     }
   }
 

--- a/src/main/java/ru/aritmos/api/ServicePointController.java
+++ b/src/main/java/ru/aritmos/api/ServicePointController.java
@@ -807,7 +807,7 @@ public class ServicePointController {
     return visitService.getVisits(branchId, queueId).stream()
         .filter(f -> f.getId().equals(visitId))
         .findFirst()
-        .orElseThrow(() -> new BusinessException("Visit not found", eventService, HttpStatus.NOT_FOUND));
+        .orElseThrow(() -> new BusinessException("Visit not found", "Визит не найден", eventService, HttpStatus.NOT_FOUND));
   }
 
   /**
@@ -1534,7 +1534,10 @@ public class ServicePointController {
                   Map.Entry::getKey, Map.Entry::getValue, (oldValue, newValue) -> oldValue));
     } else {
       throw new BusinessException(
-          String.format("Service %s not found", serviceId), eventService, HttpStatus.NOT_FOUND);
+          String.format("Service %s not found", serviceId),
+          String.format("Услуга %s не найдена", serviceId),
+          eventService,
+          HttpStatus.NOT_FOUND);
     }
   }
 
@@ -1698,7 +1701,10 @@ public class ServicePointController {
       return branch.getServices().get(serviceId).getPossibleOutcomes();
     } else {
       throw new BusinessException(
-          String.format("Service %s not found", serviceId), eventService, HttpStatus.NOT_FOUND);
+          String.format("Service %s not found", serviceId),
+          String.format("Услуга %s не найдена", serviceId),
+          eventService,
+          HttpStatus.NOT_FOUND);
     }
   }
 
@@ -2360,6 +2366,7 @@ public class ServicePointController {
     if (!visitService.getAllVisits(branchId).containsKey(visitId)) {
       throw new BusinessException(
           String.format("Visit with id %s not found", visitId),
+          String.format("Визит с идентификатором %s не найден", visitId),
           eventService,
           HttpStatus.NOT_FOUND);
     }
@@ -2409,10 +2416,10 @@ public class ServicePointController {
     try {
       branch = branchService.getBranch(branchId);
     } catch (Exception ex) {
-      throw new BusinessException("Branch not found", eventService, HttpStatus.NOT_FOUND);
+      throw new BusinessException("Branch not found", "Отделение не найдено", eventService, HttpStatus.NOT_FOUND);
     }
     if (!branch.getQueues().containsKey(queueId)) {
-      throw new BusinessException("Queue not found", eventService, HttpStatus.NOT_FOUND);
+      throw new BusinessException("Queue not found", "Очередь не найдена", eventService, HttpStatus.NOT_FOUND);
     }
 
     return visitService.visitTransfer(
@@ -2460,10 +2467,10 @@ public class ServicePointController {
     try {
       branch = branchService.getBranch(branchId);
     } catch (Exception ex) {
-      throw new BusinessException("Branch not found", eventService, HttpStatus.NOT_FOUND);
+      throw new BusinessException("Branch not found", "Отделение не найдено", eventService, HttpStatus.NOT_FOUND);
     }
     if (!branch.getServicePoints().containsKey(poolServicePointId)) {
-      throw new BusinessException("Service point not found", eventService, HttpStatus.NOT_FOUND);
+      throw new BusinessException("Service point not found", "Точка обслуживания не найдена", eventService, HttpStatus.NOT_FOUND);
     }
 
     return visitService.visitBackToServicePointPool(
@@ -2512,10 +2519,10 @@ public class ServicePointController {
     try {
       branch = branchService.getBranch(branchId);
     } catch (Exception ex) {
-      throw new BusinessException("Branch not found", eventService, HttpStatus.NOT_FOUND);
+      throw new BusinessException("Branch not found", "Отделение не найдено", eventService, HttpStatus.NOT_FOUND);
     }
     if (!branch.getServicePoints().containsKey(poolServicePointId)) {
-      throw new BusinessException("Service point not found", eventService, HttpStatus.NOT_FOUND);
+      throw new BusinessException("Service point not found", "Точка обслуживания не найдена", eventService, HttpStatus.NOT_FOUND);
     }
 
     return visitService.visitTransferToServicePointPool(
@@ -2556,10 +2563,10 @@ public class ServicePointController {
     try {
       branch = branchService.getBranch(branchId);
     } catch (Exception ex) {
-      throw new BusinessException("Branch not found", eventService, HttpStatus.NOT_FOUND);
+      throw new BusinessException("Branch not found", "Отделение не найдено", eventService, HttpStatus.NOT_FOUND);
     }
     if (!branch.getServicePoints().containsKey(poolServicePointId)) {
-      throw new BusinessException("Service point not found", eventService, HttpStatus.NOT_FOUND);
+      throw new BusinessException("Service point not found", "Точка обслуживания не найдена", eventService, HttpStatus.NOT_FOUND);
     }
 
     return visitService.visitTransferToServicePointPool(
@@ -2646,10 +2653,10 @@ public class ServicePointController {
     try {
       branch = branchService.getBranch(branchId);
     } catch (Exception ex) {
-      throw new BusinessException("Branch not found", eventService, HttpStatus.NOT_FOUND);
+      throw new BusinessException("Branch not found", "Отделение не найдено", eventService, HttpStatus.NOT_FOUND);
     }
     if (!branch.getQueues().containsKey(queueId)) {
-      throw new BusinessException("Queue not found", eventService, HttpStatus.NOT_FOUND);
+      throw new BusinessException("Queue not found", "Очередь не найдена", eventService, HttpStatus.NOT_FOUND);
     }
 
     Visit visit = visitService.getVisit(branchId, visitId);
@@ -2702,10 +2709,10 @@ public class ServicePointController {
     try {
       branch = branchService.getBranch(branchId);
     } catch (Exception ex) {
-      throw new BusinessException("Branch not found", eventService, HttpStatus.NOT_FOUND);
+      throw new BusinessException("Branch not found", "Отделение не найдено", eventService, HttpStatus.NOT_FOUND);
     }
     if (!branch.getQueues().containsKey(queueId)) {
-      throw new BusinessException("Queue not found", eventService, HttpStatus.NOT_FOUND);
+      throw new BusinessException("Queue not found", "Очередь не найдена", eventService, HttpStatus.NOT_FOUND);
     }
 
     Visit visit = visitService.getVisit(branchId, visitId);
@@ -2758,10 +2765,10 @@ public class ServicePointController {
     try {
       branch = branchService.getBranch(branchId);
     } catch (Exception ex) {
-      throw new BusinessException("Branch not found", eventService, HttpStatus.NOT_FOUND);
+      throw new BusinessException("Branch not found", "Отделение не найдено", eventService, HttpStatus.NOT_FOUND);
     }
     if (!branch.getQueues().containsKey(queueId)) {
-      throw new BusinessException("Queue not found", eventService, HttpStatus.NOT_FOUND);
+      throw new BusinessException("Queue not found", "Очередь не найдена", eventService, HttpStatus.NOT_FOUND);
     }
 
     Visit visit = visitService.getVisit(branchId, visitId);
@@ -2813,10 +2820,10 @@ public class ServicePointController {
     try {
       branch = branchService.getBranch(branchId);
     } catch (Exception ex) {
-      throw new BusinessException("Branch not found", eventService, HttpStatus.NOT_FOUND);
+      throw new BusinessException("Branch not found", "Отделение не найдено", eventService, HttpStatus.NOT_FOUND);
     }
     if (!branch.getQueues().containsKey(queueId)) {
-      throw new BusinessException("Queue not found", eventService, HttpStatus.NOT_FOUND);
+      throw new BusinessException("Queue not found", "Очередь не найдена", eventService, HttpStatus.NOT_FOUND);
     }
 
     return visitService.visitTransfer(
@@ -2867,10 +2874,10 @@ public class ServicePointController {
     try {
       branch = branchService.getBranch(branchId);
     } catch (Exception ex) {
-      throw new BusinessException("Branch not found", eventService, HttpStatus.NOT_FOUND);
+      throw new BusinessException("Branch not found", "Отделение не найдено", eventService, HttpStatus.NOT_FOUND);
     }
     if (!branch.getQueues().containsKey(queueId)) {
-      throw new BusinessException("Queue not found", eventService, HttpStatus.NOT_FOUND);
+      throw new BusinessException("Queue not found", "Очередь не найдена", eventService, HttpStatus.NOT_FOUND);
     }
 
     return visitService.visitTransfer(
@@ -2920,10 +2927,10 @@ public class ServicePointController {
     try {
       branch = branchService.getBranch(branchId);
     } catch (Exception ex) {
-      throw new BusinessException("Branch not found", eventService, HttpStatus.NOT_FOUND);
+      throw new BusinessException("Branch not found", "Отделение не найдено", eventService, HttpStatus.NOT_FOUND);
     }
     if (!branch.getServicePoints().containsKey(poolServicePointId)) {
-      throw new BusinessException("Service point not found", eventService, HttpStatus.NOT_FOUND);
+      throw new BusinessException("Service point not found", "Точка обслуживания не найдена", eventService, HttpStatus.NOT_FOUND);
     }
 
     return visitService.visitTransferFromQueueToServicePointPool(
@@ -2973,10 +2980,10 @@ public class ServicePointController {
     try {
       branch = branchService.getBranch(branchId);
     } catch (Exception ex) {
-      throw new BusinessException("Branch not found", eventService, HttpStatus.NOT_FOUND);
+      throw new BusinessException("Branch not found", "Отделение не найдено", eventService, HttpStatus.NOT_FOUND);
     }
     if (!branch.getServicePoints().containsKey(poolServicePointId)) {
-      throw new BusinessException("Service point not found", eventService, HttpStatus.NOT_FOUND);
+      throw new BusinessException("Service point not found", "Точка обслуживания не найдена", eventService, HttpStatus.NOT_FOUND);
     }
 
     return visitService.visitTransferFromQueueToServicePointPool(
@@ -3029,10 +3036,10 @@ public class ServicePointController {
     try {
       branch = branchService.getBranch(branchId);
     } catch (Exception ex) {
-      throw new BusinessException("Branch not found", eventService, HttpStatus.NOT_FOUND);
+      throw new BusinessException("Branch not found", "Отделение не найдено", eventService, HttpStatus.NOT_FOUND);
     }
     if (!branch.getServicePoints().containsKey(servicePointId)) {
-      throw new BusinessException("Service point not found", eventService, HttpStatus.NOT_FOUND);
+      throw new BusinessException("Service point not found", "Точка обслуживания не найдена", eventService, HttpStatus.NOT_FOUND);
     }
 
     return visitService.visitTransferFromQueueToServicePointPool(

--- a/src/main/java/ru/aritmos/keycloack/service/KeyCloackClient.java
+++ b/src/main/java/ru/aritmos/keycloack/service/KeyCloackClient.java
@@ -118,6 +118,7 @@ public class KeyCloackClient {
                 () ->
                     new BusinessException(
                         String.format("Region %s not found", regionName),
+                        String.format("Регион %s не найден", regionName),
                         eventService,
                         HttpStatus.NOT_FOUND))
             .getId();

--- a/src/main/java/ru/aritmos/model/Branch.java
+++ b/src/main/java/ru/aritmos/model/Branch.java
@@ -275,11 +275,23 @@ public class Branch extends BranchEntity {
                       servicePoint.getUser().getName()));
           ObjectMapper objectMapper = ObjectMapper.getDefault();
 
-          throw new BusinessException(errorBody, eventService, HttpStatus.CONFLICT, objectMapper);
+          throw new BusinessException(
+              errorBody,
+              String.format(
+                  "Точка обслуживания %s уже занята пользователем %s",
+                  servicePoint.getName(),
+                  servicePoint.getUser().getName()),
+              eventService,
+              HttpStatus.CONFLICT,
+              objectMapper);
         }
       } else {
         throw new BusinessException(
             String.format("ServicePoint %s not found in %s", user.servicePointId, this.getName()),
+            String.format(
+                "Точка обслуживания %s не найдена в отделении %s",
+                user.servicePointId,
+                this.getName()),
             eventService,
             HttpStatus.CONFLICT);
       }
@@ -417,6 +429,7 @@ public class Branch extends BranchEntity {
       } else {
         throw new BusinessException(
             String.format("Service point %s is already closed", servicePointId),
+            String.format("Точка обслуживания %s уже закрыта", servicePointId),
             eventService,
             HttpStatus.CONFLICT);
       }
@@ -424,6 +437,10 @@ public class Branch extends BranchEntity {
     } else {
       throw new BusinessException(
           String.format("ServicePoint %s not found in %s", servicePointId, this.getName()),
+          String.format(
+              "Точка обслуживания %s не найдена в отделении %s",
+              servicePointId,
+              this.getName()),
           eventService,
           HttpStatus.NOT_FOUND);
     }
@@ -467,6 +484,10 @@ public class Branch extends BranchEntity {
                   String.format(
                       "In ServicePoint %s already exists visit %s",
                       value.getId(), value.getVisit().getId()),
+                  String.format(
+                      "В точке обслуживания %s уже закреплён визит %s",
+                      value.getId(),
+                      value.getVisit().getId()),
                   eventService,
                   HttpStatus.CONFLICT);
             }
@@ -565,6 +586,10 @@ public class Branch extends BranchEntity {
           throw new BusinessException(
               String.format(
                   "Visit position %s is out of range for list size %s", index, v.getVisits().size()),
+              String.format(
+                  "Позиция визита %s выходит за пределы размера списка %s",
+                  index,
+                  v.getVisits().size()),
               eventService,
               HttpStatus.CONFLICT);
         }
@@ -588,6 +613,10 @@ public class Branch extends BranchEntity {
               String.format(
                   "In ServicePoint %s already exists visit %s",
                   value.getId(), value.getVisit().getId()),
+              String.format(
+                  "В точке обслуживания %s уже закреплён визит %s",
+                  value.getId(),
+                  value.getVisit().getId()),
               eventService,
               HttpStatus.CONFLICT);
         }
@@ -606,6 +635,10 @@ public class Branch extends BranchEntity {
               String.format(
                   "Visit position %s is out of range for list size %s",
                   index, value.getVisits().size()),
+              String.format(
+                  "Позиция визита %s выходит за пределы размера списка %s",
+                  index,
+                  value.getVisits().size()),
               eventService,
               HttpStatus.CONFLICT);
         }
@@ -627,6 +660,10 @@ public class Branch extends BranchEntity {
                 String.format(
                     "Visit position %s is out of range for list size %s",
                     index, value.getUser().getVisits().size()),
+                String.format(
+                    "Позиция визита %s выходит за пределы размера списка %s",
+                    index,
+                    value.getUser().getVisits().size()),
                 eventService,
                 HttpStatus.CONFLICT);
           }
@@ -730,6 +767,7 @@ public class Branch extends BranchEntity {
                             || v2.getCurrentService().getId().equals(k)) {
                           throw new BusinessException(
                               "Updated service " + k + " is currently in use",
+                              String.format("Обновляемая услуга %s используется в текущих визитах", k),
                               eventService,
                               HttpStatus.CONFLICT);
                         }
@@ -807,6 +845,7 @@ public class Branch extends BranchEntity {
                             || v2.getCurrentService().getId().equals(id)) {
                           throw new BusinessException(
                               "Delete service " + id + " is currently in use",
+                              String.format("Удаляемая услуга %s используется в текущих визитах", id),
                               eventService,
                               HttpStatus.CONFLICT);
                         }
@@ -835,7 +874,10 @@ public class Branch extends BranchEntity {
                 serviceId -> {
                   if (!this.getServices().containsKey(serviceId)) {
                     throw new BusinessException(
-                        "Service " + serviceId + " not found", eventService, HttpStatus.NOT_FOUND);
+                        "Service " + serviceId + " not found",
+                        String.format("Услуга %s не найдена", serviceId),
+                        eventService,
+                        HttpStatus.NOT_FOUND);
                   } else {
                     this.getServices().get(serviceId).setServiceGroupId(key);
                   }
@@ -985,6 +1027,7 @@ public class Branch extends BranchEntity {
           if (!this.getServiceGroups().containsKey(value.serviceGroupId)) {
             throw new BusinessException(
                 "Service group " + value.serviceGroupId + " not found",
+                String.format("Группа услуг %s не найдена", value.serviceGroupId),
                 eventService,
                 HttpStatus.NOT_FOUND);
           }

--- a/src/main/java/ru/aritmos/service/BranchService.java
+++ b/src/main/java/ru/aritmos/service/BranchService.java
@@ -50,7 +50,8 @@ public class BranchService {
 
     Branch branch = branches.get(key);
     if (branch == null) {
-      throw new BusinessException("Branch not found", eventService, HttpStatus.NOT_FOUND);
+      throw new BusinessException(
+          "Branch not found", "Отделение не найдено", eventService, HttpStatus.NOT_FOUND);
     }
     log.info("Getting branchInfo {}", branch);
     return branch;
@@ -179,7 +180,8 @@ public class BranchService {
       // eventService.sendChangedEvent("*", true, oldBranch, null, new HashMap<>(), "DELETED");
 
     } else {
-      throw new BusinessException("Branch not found", eventService, HttpStatus.NOT_FOUND);
+      throw new BusinessException(
+          "Branch not found", "Отделение не найдено", eventService, HttpStatus.NOT_FOUND);
     }
     log.info("Deleting branchInfo {}", key);
     branches.remove(key);
@@ -254,15 +256,20 @@ public class BranchService {
       String branchId, String servicePointId, String workProfileId) throws BusinessException {
     Branch branch = this.getBranch(branchId);
     if (!branch.getWorkProfiles().containsKey(workProfileId)) {
-      throw new BusinessException("Work profile not found", eventService, HttpStatus.NOT_FOUND);
+      throw new BusinessException(
+          "Work profile not found", "Рабочий профиль не найден", eventService, HttpStatus.NOT_FOUND);
     }
     if (!branch.getServicePoints().containsKey(servicePointId)) {
-      throw new BusinessException("Service point not found", eventService, HttpStatus.NOT_FOUND);
+      throw new BusinessException(
+          "Service point not found", "Точка обслуживания не найдена", eventService, HttpStatus.NOT_FOUND);
     }
     User user = branch.getServicePoints().get(servicePointId).getUser();
     if (user == null) {
       throw new BusinessException(
-          "User not found in the service point", eventService, HttpStatus.NOT_FOUND);
+          "User not found in the service point",
+          "Пользователь не найден в точке обслуживания",
+          eventService,
+          HttpStatus.NOT_FOUND);
     }
     String oldWorkProfileId = user.getCurrentWorkProfileId();
     branch.getServicePoints().get(servicePointId).getUser().setCurrentWorkProfileId(workProfileId);
@@ -293,10 +300,12 @@ public class BranchService {
       throws BusinessException, IOException {
     Branch branch = this.getBranch(branchId);
     if (!branch.getWorkProfiles().containsKey(workProfileId)) {
-      throw new BusinessException("Work profile not found", eventService, HttpStatus.NOT_FOUND);
+      throw new BusinessException(
+          "Work profile not found", "Рабочий профиль не найден", eventService, HttpStatus.NOT_FOUND);
     }
     if (!branch.getServicePoints().containsKey(servicePointId)) {
-      throw new BusinessException("Service point not found", eventService, HttpStatus.NOT_FOUND);
+      throw new BusinessException(
+          "Service point not found", "Точка обслуживания не найдена", eventService, HttpStatus.NOT_FOUND);
     }
     Optional<UserRepresentation> userInfo = Optional.empty();
 
@@ -376,6 +385,10 @@ public class BranchService {
             String.format(
                 "User %s does not have permission to access branch '%s'",
                 userName, branch.getName()),
+            String.format(
+                "У пользователя %s нет доступа к отделению «%s»",
+                userName,
+                branch.getName()),
             eventService,
             HttpStatus.valueOf(403));
       }
@@ -650,7 +663,8 @@ public class BranchService {
   public List<Service> getServicesByWorkProfileId(String branchId, String workProfileId) {
     Branch branch = this.getBranch(branchId);
     if (!branch.getWorkProfiles().containsKey(workProfileId)) {
-      throw new BusinessException("Work profile not found", eventService, HttpStatus.NOT_FOUND);
+      throw new BusinessException(
+          "Work profile not found", "Рабочий профиль не найден", eventService, HttpStatus.NOT_FOUND);
     }
     List<Service> services = new ArrayList<>();
     branch
@@ -676,7 +690,8 @@ public class BranchService {
   public List<Service> getServicesByQueueId(String branchId, String queueId) {
     Branch branch = this.getBranch(branchId);
     if (!branch.getQueues().containsKey(queueId)) {
-      throw new BusinessException("Queue not found", eventService, HttpStatus.NOT_FOUND);
+      throw new BusinessException(
+          "Queue not found", "Очередь не найдена", eventService, HttpStatus.NOT_FOUND);
     }
     return new ArrayList<>(
         branch.getServices().values().stream()

--- a/src/main/java/ru/aritmos/service/VisitService.java
+++ b/src/main/java/ru/aritmos/service/VisitService.java
@@ -65,7 +65,10 @@ public class VisitService {
       return getAllVisits(branchId).get(visitId);
     }
     throw new BusinessException(
-        String.format("Visit %s not found", visitId), eventService, HttpStatus.NOT_FOUND);
+        String.format("Visit %s not found", visitId),
+        String.format("Визит %s не найден", visitId),
+        eventService,
+        HttpStatus.NOT_FOUND);
   }
 
   /**
@@ -138,7 +141,7 @@ public class VisitService {
       queue = currentBranch.getQueues().get(queueId);
     } else {
       throw new BusinessException(
-          "Queue not found in branch configuration", eventService, HttpStatus.NOT_FOUND);
+          "Queue not found in branch configuration", "Очередь не найдена в конфигурации отделения", eventService, HttpStatus.NOT_FOUND);
     }
     List<Visit> visits;
     visits =
@@ -195,7 +198,7 @@ public class VisitService {
               branchId, entryPointId, services, visitParameters.getParameters(), printTicket));
 
     } else {
-      throw new BusinessException("Services not found", eventService, HttpStatus.NOT_FOUND);
+      throw new BusinessException("Services not found", "Услуги не найдены", eventService, HttpStatus.NOT_FOUND);
     }
   }
 
@@ -233,7 +236,7 @@ public class VisitService {
               segmentationRuleId));
 
     } else {
-      throw new BusinessException("Services not found", eventService, HttpStatus.NOT_FOUND);
+      throw new BusinessException("Services not found", "Услуги не найдены", eventService, HttpStatus.NOT_FOUND);
     }
   }
 
@@ -266,7 +269,7 @@ public class VisitService {
               branchId, printerId, services, visitParameters.getParameters(), printTicket, sid));
 
     } else {
-      throw new BusinessException("Services not found", eventService, HttpStatus.NOT_FOUND);
+      throw new BusinessException("Services not found", "Услуги не найдены", eventService, HttpStatus.NOT_FOUND);
     }
   }
 
@@ -305,7 +308,7 @@ public class VisitService {
               sid));
 
     } else {
-      throw new BusinessException("Services not found", eventService, HttpStatus.NOT_FOUND);
+      throw new BusinessException("Services not found", "Услуги не найдены", eventService, HttpStatus.NOT_FOUND);
     }
   }
 
@@ -318,7 +321,7 @@ public class VisitService {
       Visit currentVisit = currentBranch.getServicePoints().get(servicePointId).getVisit();
       if (ChronoUnit.SECONDS.between(currentVisit.getCreateDateTime(), ZonedDateTime.now()) < 5) {
         throw new BusinessException(
-            "Visit is already created in the service point", eventService, HttpStatus.CONFLICT);
+            "Visit is already created in the service point", "Визит уже создан в точке обслуживания", eventService, HttpStatus.CONFLICT);
       }
     }
 
@@ -333,7 +336,7 @@ public class VisitService {
           branchId, servicePointId, services, visitParameters.getParameters(), sid);
 
     } else {
-      throw new BusinessException("Services not found", eventService, HttpStatus.NOT_FOUND);
+      throw new BusinessException("Services not found", "Услуги не найдены", eventService, HttpStatus.NOT_FOUND);
     }
   }
 
@@ -347,7 +350,7 @@ public class VisitService {
   public void addEvent(Visit visit, VisitEvent event, EventService eventService) {
     if (visit.getVisitEvents().isEmpty()) {
       if (!event.equals(VisitEvent.CREATED))
-        throw new BusinessException("Visit must be created first", eventService, HttpStatus.CONFLICT);
+        throw new BusinessException("Visit must be created first", "Сначала необходимо создать визит", eventService, HttpStatus.CONFLICT);
       else {
         visit
             .getEvents()
@@ -376,7 +379,10 @@ public class VisitService {
       } else
         throw new BusinessException(
             String.format(
-                "%s can't be next status %s",
+                "Event %s cannot transition the visit to status %s",
+                event.name(), visit.getVisitEvents().get(visit.getVisitEvents().size() - 1).name()),
+            String.format(
+                "Событие %s не может перевести визит в статус %s",
                 event.name(), visit.getVisitEvents().get(visit.getVisitEvents().size() - 1).name()),
             eventService,
             HttpStatus.CONFLICT);
@@ -426,12 +432,12 @@ public class VisitService {
 
       } else {
         throw new BusinessException(
-            "User is not logged into the service point", eventService, HttpStatus.FORBIDDEN);
+            "User is not logged into the service point", "Пользователь не авторизован в точке обслуживания", eventService, HttpStatus.FORBIDDEN);
       }
 
     } else {
       throw new BusinessException(
-          "Service point not found in branch configuration", eventService, HttpStatus.NOT_FOUND);
+          "Service point not found in branch configuration", "Точка обслуживания не найдена в конфигурации отделения", eventService, HttpStatus.NOT_FOUND);
     }
   }
 
@@ -496,7 +502,7 @@ public class VisitService {
 
         if (!currentBranch.getEntryPoints().containsKey(entryPointId)) {
           throw new BusinessException(
-              "Entry point not found in branch configuration", eventService, HttpStatus.NOT_FOUND);
+              "Entry point not found in branch configuration", "Точка входа не найдена в конфигурации отделения", eventService, HttpStatus.NOT_FOUND);
         } else {
           entryPoint = currentBranch.getEntryPoints().get(entryPointId);
         }
@@ -579,21 +585,21 @@ public class VisitService {
             return visit;
           } else {
             throw new BusinessException(
-                "Queue not found in branch configuration", eventService, HttpStatus.NOT_FOUND);
+                "Queue not found in branch configuration", "Очередь не найдена в конфигурации отделения", eventService, HttpStatus.NOT_FOUND);
           }
 
         } else {
           throw new BusinessException(
-              "Services cannot be empty", eventService, HttpStatus.BAD_REQUEST);
+              "Services cannot be empty", "Список услуг не может быть пустым", eventService, HttpStatus.BAD_REQUEST);
         }
       } else {
         throw new BusinessException(
-            "Service not found in branch configuration", eventService, HttpStatus.NOT_FOUND);
+            "Service not found in branch configuration", "Услуга не найдена в конфигурации отделения", eventService, HttpStatus.NOT_FOUND);
       }
     }
 
     throw new BusinessException(
-        "Queue not found in branch configuration", eventService, HttpStatus.NOT_FOUND);
+        "Queue not found in branch configuration", "Очередь не найдена в конфигурации отделения", eventService, HttpStatus.NOT_FOUND);
   }
 
   /**
@@ -626,7 +632,7 @@ public class VisitService {
 
         if (!currentBranch.getEntryPoints().containsKey(entryPointId)) {
           throw new BusinessException(
-              "Entry point not found in branch configuration", eventService, HttpStatus.NOT_FOUND);
+              "Entry point not found in branch configuration", "Точка входа не найдена в конфигурации отделения", eventService, HttpStatus.NOT_FOUND);
         } else {
           entryPoint = currentBranch.getEntryPoints().get(entryPointId);
         }
@@ -711,21 +717,21 @@ public class VisitService {
             return visit;
           } else {
             throw new BusinessException(
-                "Queue not found in branch configuration", eventService, HttpStatus.NOT_FOUND);
+                "Queue not found in branch configuration", "Очередь не найдена в конфигурации отделения", eventService, HttpStatus.NOT_FOUND);
           }
 
         } else {
           throw new BusinessException(
-              "Services cannot be empty", eventService, HttpStatus.BAD_REQUEST);
+              "Services cannot be empty", "Список услуг не может быть пустым", eventService, HttpStatus.BAD_REQUEST);
         }
       } else {
         throw new BusinessException(
-            "Service not found in branch configuration", eventService, HttpStatus.NOT_FOUND);
+            "Service not found in branch configuration", "Услуга не найдена в конфигурации отделения", eventService, HttpStatus.NOT_FOUND);
       }
     }
 
     throw new BusinessException(
-        "Queue not found in branch configuration", eventService, HttpStatus.NOT_FOUND);
+        "Queue not found in branch configuration", "Очередь не найдена в конфигурации отделения", eventService, HttpStatus.NOT_FOUND);
   }
 
   /**
@@ -840,21 +846,21 @@ public class VisitService {
             return visit;
           } else {
             throw new BusinessException(
-                "Queue not found in branch configuration", eventService, HttpStatus.NOT_FOUND);
+                "Queue not found in branch configuration", "Очередь не найдена в конфигурации отделения", eventService, HttpStatus.NOT_FOUND);
           }
 
         } else {
           throw new BusinessException(
-              "Services cannot be empty", eventService, HttpStatus.BAD_REQUEST);
+              "Services cannot be empty", "Список услуг не может быть пустым", eventService, HttpStatus.BAD_REQUEST);
         }
       } else {
         throw new BusinessException(
-            "Service not found in branch configuration", eventService, HttpStatus.NOT_FOUND);
+            "Service not found in branch configuration", "Услуга не найдена в конфигурации отделения", eventService, HttpStatus.NOT_FOUND);
       }
     }
 
     throw new BusinessException(
-        "Queue not found in branch configuration", eventService, HttpStatus.NOT_FOUND);
+        "Queue not found in branch configuration", "Очередь не найдена в конфигурации отделения", eventService, HttpStatus.NOT_FOUND);
   }
 
   /**
@@ -966,21 +972,21 @@ public class VisitService {
             return visit;
           } else {
             throw new BusinessException(
-                "Queue not found in branch configuration", eventService, HttpStatus.NOT_FOUND);
+                "Queue not found in branch configuration", "Очередь не найдена в конфигурации отделения", eventService, HttpStatus.NOT_FOUND);
           }
 
         } else {
           throw new BusinessException(
-              "Services cannot be empty", eventService, HttpStatus.BAD_REQUEST);
+              "Services cannot be empty", "Список услуг не может быть пустым", eventService, HttpStatus.BAD_REQUEST);
         }
       } else {
         throw new BusinessException(
-            "Service not found in branch configuration", eventService, HttpStatus.NOT_FOUND);
+            "Service not found in branch configuration", "Услуга не найдена в конфигурации отделения", eventService, HttpStatus.NOT_FOUND);
       }
     }
 
     throw new BusinessException(
-        "Queue not found in branch configuration", eventService, HttpStatus.NOT_FOUND);
+        "Queue not found in branch configuration", "Очередь не найдена в конфигурации отделения", eventService, HttpStatus.NOT_FOUND);
   }
 
   /**
@@ -1192,21 +1198,21 @@ public class VisitService {
             return visit;
           } else {
             throw new BusinessException(
-                "Queue not found in branch configuration", eventService, HttpStatus.NOT_FOUND);
+                "Queue not found in branch configuration", "Очередь не найдена в конфигурации отделения", eventService, HttpStatus.NOT_FOUND);
           }
 
         } else {
           throw new BusinessException(
-              "Services cannot be empty", eventService, HttpStatus.BAD_REQUEST);
+              "Services cannot be empty", "Список услуг не может быть пустым", eventService, HttpStatus.BAD_REQUEST);
         }
       } else {
         throw new BusinessException(
-            "Service not found in branch configuration", eventService, HttpStatus.NOT_FOUND);
+            "Service not found in branch configuration", "Услуга не найдена в конфигурации отделения", eventService, HttpStatus.NOT_FOUND);
       }
     }
 
     throw new BusinessException(
-        "Queue not found in branch configuration", eventService, HttpStatus.NOT_FOUND);
+        "Queue not found in branch configuration", "Очередь не найдена в конфигурации отделения", eventService, HttpStatus.NOT_FOUND);
   }
 
   /**
@@ -1226,7 +1232,7 @@ public class VisitService {
         Visit visit = servicePoint.getVisit();
         if (visit.getCurrentService() == null) {
           throw new BusinessException(
-              "Current service is null", eventService, HttpStatus.NOT_FOUND);
+              "Current service is null", "Текущая услуга отсутствует", eventService, HttpStatus.NOT_FOUND);
         }
 
         Service currentService = visit.getCurrentService().clone();
@@ -1253,11 +1259,13 @@ public class VisitService {
         Visit visit = servicePoint.getVisit();
         if (visit.getCurrentService() == null) {
           throw new BusinessException(
-              "Current service is null", eventService, HttpStatus.NOT_FOUND);
+              "Current service is null", "Текущая услуга отсутствует", eventService, HttpStatus.NOT_FOUND);
         }
         if (!currentBranch.getPossibleDeliveredServices().containsKey(deliveredServiceId)) {
           throw new BusinessException(
               String.format("Delivered service with id %s not found", deliveredServiceId),
+              String.format(
+                  "Фактическая услуга с идентификатором %s не найдена", deliveredServiceId),
               eventService,
               HttpStatus.NOT_FOUND);
         }
@@ -1266,6 +1274,8 @@ public class VisitService {
           throw new BusinessException(
               String.format(
                   "Current service cannot add delivered service with id %s", deliveredServiceId),
+              String.format(
+                  "Текущая услуга не позволяет добавить фактическую услугу с идентификатором %s", deliveredServiceId),
               eventService,
               HttpStatus.CONFLICT);
         }
@@ -1318,12 +1328,14 @@ public class VisitService {
       } else {
         throw new BusinessException(
             String.format("Visit in service point %s does not exist", servicePointId),
+            String.format("Визит в точке обслуживания %s отсутствует", servicePointId),
             eventService,
             HttpStatus.NOT_FOUND);
       }
     } else {
       throw new BusinessException(
           String.format("Service point %s does not exist", servicePointId),
+          String.format("Точка обслуживания %s не существует", servicePointId),
           eventService,
           HttpStatus.NOT_FOUND);
     }
@@ -1346,12 +1358,14 @@ public class VisitService {
         Visit visit = servicePoint.getVisit();
         if (visit.getCurrentService() == null) {
           throw new BusinessException(
-              "Current service is null", eventService, HttpStatus.NOT_FOUND);
+              "Current service is null", "Текущая услуга отсутствует", eventService, HttpStatus.NOT_FOUND);
         }
         if (!currentBranch.getPossibleDeliveredServices().containsKey(deliveredServiceId)
             && !visit.getCurrentService().getDeliveredServices().containsKey(deliveredServiceId)) {
           throw new BusinessException(
               String.format("Delivered service with id %s not found", deliveredServiceId),
+              String.format(
+                  "Фактическая услуга с идентификатором %s не найдена", deliveredServiceId),
               eventService,
               HttpStatus.NOT_FOUND);
         }
@@ -1360,6 +1374,8 @@ public class VisitService {
           throw new BusinessException(
               String.format(
                   "Current service cannot delete delivered service with id %s", deliveredServiceId),
+              String.format(
+                  "Текущая услуга не позволяет удалить фактическую услугу с идентификатором %s", deliveredServiceId),
               eventService,
               HttpStatus.CONFLICT);
         }
@@ -1401,12 +1417,14 @@ public class VisitService {
       } else {
         throw new BusinessException(
             String.format("Visit in service point %s does not exist", servicePointId),
+            String.format("Визит в точке обслуживания %s отсутствует", servicePointId),
             eventService,
             HttpStatus.NOT_FOUND);
       }
     } else {
       throw new BusinessException(
           String.format("Service point %s does not exist", servicePointId),
+          String.format("Точка обслуживания %s не существует", servicePointId),
           eventService,
           HttpStatus.NOT_FOUND);
     }
@@ -1430,6 +1448,7 @@ public class VisitService {
         if (currentBranch.getServices().keySet().stream().noneMatch(f -> f.contains(serviceId))) {
           throw new BusinessException(
               String.format("Current visit cannot add service with id %s", serviceId),
+              String.format("Текущий визит не может добавить услугу с идентификатором %s", serviceId),
               eventService,
               HttpStatus.CONFLICT);
         }
@@ -1463,12 +1482,14 @@ public class VisitService {
       } else {
         throw new BusinessException(
             String.format("Visit in service point %s does not exist", servicePointId),
+            String.format("Визит в точке обслуживания %s отсутствует", servicePointId),
             eventService,
             HttpStatus.NOT_FOUND);
       }
     } else {
       throw new BusinessException(
           String.format("Service point %s does not exist", servicePointId),
+          String.format("Точка обслуживания %s не существует", servicePointId),
           eventService,
           HttpStatus.NOT_FOUND);
     }
@@ -1490,7 +1511,7 @@ public class VisitService {
         Visit visit = servicePoint.getVisit();
         if (visit.getCurrentService() == null)
           throw new BusinessException(
-              "Current service is null", eventService, HttpStatus.NOT_FOUND);
+              "Current service is null", "Текущая услуга отсутствует", eventService, HttpStatus.NOT_FOUND);
         mark.setMarkDate(ZonedDateTime.now());
         if (servicePoint.getUser() != null) {
           User user = servicePoint.getUser().toBuilder().build();
@@ -1529,12 +1550,14 @@ public class VisitService {
       } else {
         throw new BusinessException(
             String.format("Visit in service point %s does not exist", servicePointId),
+            String.format("Визит в точке обслуживания %s отсутствует", servicePointId),
             eventService,
             HttpStatus.NOT_FOUND);
       }
     } else {
       throw new BusinessException(
           String.format("Service point %s does not exist", servicePointId),
+          String.format("Точка обслуживания %s не существует", servicePointId),
           eventService,
           HttpStatus.NOT_FOUND);
     }
@@ -1556,7 +1579,7 @@ public class VisitService {
         Visit visit = servicePoint.getVisit();
         if (visit.getCurrentService() == null)
           throw new BusinessException(
-              "Current service is null", eventService, HttpStatus.NOT_FOUND);
+              "Current service is null", "Текущая услуга отсутствует", eventService, HttpStatus.NOT_FOUND);
         visit.getVisitMarks().removeIf(f -> f.getId().equals(mark.getId()));
         VisitEvent visitEvent = VisitEvent.DELETED_MARK;
         visitEvent.getParameters().put("servicePointId", servicePoint.getId());
@@ -1583,12 +1606,14 @@ public class VisitService {
       } else {
         throw new BusinessException(
             String.format("Visit in service point %s does not exist", servicePointId),
+            String.format("Визит в точке обслуживания %s отсутствует", servicePointId),
             eventService,
             HttpStatus.NOT_FOUND);
       }
     } else {
       throw new BusinessException(
           String.format("Service point %s does not exist", servicePointId),
+          String.format("Точка обслуживания %s не существует", servicePointId),
           eventService,
           HttpStatus.NOT_FOUND);
     }
@@ -1607,8 +1632,11 @@ public class VisitService {
     if (currentBranch.getMarks().containsKey(markId)) {
       return deleteMark(branchId, servicePointId, currentBranch.getMarks().get(markId));
     } else {
-      throw new BusinessException(
-          String.format("Mark %s not found", markId), eventService, HttpStatus.NOT_FOUND);
+        throw new BusinessException(
+            String.format("Mark %s not found", markId),
+            String.format("Метка %s не найдена", markId),
+            eventService,
+            HttpStatus.NOT_FOUND);
     }
   }
 
@@ -1625,8 +1653,11 @@ public class VisitService {
       Visit visit = currentBranch.getAllVisits().get(visitId);
       return visit.getVisitMarks();
     } else {
-      throw new BusinessException(
-          String.format("Visit %s not found", visitId), eventService, HttpStatus.NOT_FOUND);
+        throw new BusinessException(
+            String.format("Visit %s not found", visitId),
+            String.format("Визит %s не найден", visitId),
+            eventService,
+            HttpStatus.NOT_FOUND);
     }
   }
 
@@ -1644,7 +1675,10 @@ public class VisitService {
       return addMark(branchId, servicePointId, currentBranch.getMarks().get(markId));
     } else {
       throw new BusinessException(
-          String.format("Mark %s not found", markId), eventService, HttpStatus.NOT_FOUND);
+          String.format("Mark %s not found", markId),
+          String.format("Метка %s не найдена", markId),
+          eventService,
+          HttpStatus.NOT_FOUND);
     }
   }
 
@@ -1664,11 +1698,12 @@ public class VisitService {
         Visit visit = servicePoint.getVisit();
         if (visit.getCurrentService() == null)
           throw new BusinessException(
-              "Current service is null", eventService, HttpStatus.NOT_FOUND);
+              "Current service is null", "Текущая услуга отсутствует", eventService, HttpStatus.NOT_FOUND);
         if (visit.getCurrentService().getPossibleOutcomes().keySet().stream()
             .noneMatch(f -> f.equals(outcomeId)))
           throw new BusinessException(
               String.format("Current service cannot add outcome with id %s", outcomeId),
+              String.format("Текущая услуга не позволяет добавить итог с идентификатором %s", outcomeId),
               eventService,
               HttpStatus.CONFLICT);
         else {
@@ -1706,12 +1741,14 @@ public class VisitService {
       } else {
         throw new BusinessException(
             String.format("Visit in service point %s does not exist", servicePointId),
+            String.format("Визит в точке обслуживания %s отсутствует", servicePointId),
             eventService,
             HttpStatus.NOT_FOUND);
       }
     } else {
       throw new BusinessException(
           String.format("Service point %s does not exist", servicePointId),
+          String.format("Точка обслуживания %s не существует", servicePointId),
           eventService,
           HttpStatus.NOT_FOUND);
     }
@@ -1735,13 +1772,17 @@ public class VisitService {
         Visit visit = servicePoint.getVisit();
         if (visit.getCurrentService() == null) {
           throw new BusinessException(
-              "Current service is null", eventService, HttpStatus.NOT_FOUND);
+              "Current service is null", "Текущая услуга отсутствует", eventService, HttpStatus.NOT_FOUND);
         }
         if (!visit.getCurrentService().getDeliveredServices().containsKey(deliveredServiceId)) {
           throw new BusinessException(
               String.format(
-                  "Delivered service %s of current service ID is not %s",
-                  visit.getCurrentService().getId(), deliveredServiceId),
+                  "Delivered service %s is not linked to the current service %s",
+                  deliveredServiceId, visit.getCurrentService().getId()),
+              String.format(
+                  "Фактическая услуга %s не связана с текущей услугой %s",
+                  deliveredServiceId,
+                  visit.getCurrentService().getId()),
               eventService,
               HttpStatus.NOT_FOUND);
         }
@@ -1755,8 +1796,12 @@ public class VisitService {
             .noneMatch(f -> f.equals(outcomeId))) {
           throw new BusinessException(
               String.format(
-                  "Current service with delivered service %s cannot add outcome with id %s",
+                  "The current service with delivered service %s cannot add outcome %s",
                   deliveredServiceId, outcomeId),
+              String.format(
+                  "Текущая услуга с фактической услугой %s не может добавить итог %s",
+                  deliveredServiceId,
+                  outcomeId),
               eventService,
               HttpStatus.NOT_FOUND);
         } else {
@@ -1826,12 +1871,14 @@ public class VisitService {
       } else {
         throw new BusinessException(
             String.format("Visit in service point %s does not exist", servicePointId),
+            String.format("Визит в точке обслуживания %s отсутствует", servicePointId),
             eventService,
             HttpStatus.NOT_FOUND);
       }
     } else {
       throw new BusinessException(
           String.format("Service point %s does not exist", servicePointId),
+          String.format("Точка обслуживания %s не существует", servicePointId),
           eventService,
           HttpStatus.NOT_FOUND);
     }
@@ -1854,13 +1901,17 @@ public class VisitService {
         Visit visit = servicePoint.getVisit();
         if (visit.getCurrentService() == null) {
           throw new BusinessException(
-              "Current service is null", eventService, HttpStatus.NOT_FOUND);
+              "Current service is null", "Текущая услуга отсутствует", eventService, HttpStatus.NOT_FOUND);
         }
         if (!visit.getCurrentService().getDeliveredServices().containsKey(deliveredServiceId)) {
           throw new BusinessException(
               String.format(
-                  "Delivered service %s of current service ID is not %s",
-                  visit.getCurrentService().getId(), deliveredServiceId),
+                  "Delivered service %s is not linked to the current service %s",
+                  deliveredServiceId, visit.getCurrentService().getId()),
+              String.format(
+                  "Фактическая услуга %s не связана с текущей услугой %s",
+                  deliveredServiceId,
+                  visit.getCurrentService().getId()),
               eventService,
               HttpStatus.NOT_FOUND);
         }
@@ -1913,12 +1964,14 @@ public class VisitService {
       } else {
         throw new BusinessException(
             String.format("Visit in service point %s does not exist", servicePointId),
+            String.format("Визит в точке обслуживания %s отсутствует", servicePointId),
             eventService,
             HttpStatus.NOT_FOUND);
       }
     } else {
       throw new BusinessException(
           String.format("Service point %s does not exist", servicePointId),
+          String.format("Точка обслуживания %s не существует", servicePointId),
           eventService,
           HttpStatus.NOT_FOUND);
     }
@@ -1941,6 +1994,7 @@ public class VisitService {
         if (!visit.getCurrentService().getId().equals(serviceId)) {
           throw new BusinessException(
               String.format("Current service ID is not %s@", serviceId),
+              String.format("Идентификатор текущей услуги отличается от %s@", serviceId),
               eventService,
               HttpStatus.BAD_REQUEST);
         }
@@ -1974,12 +2028,14 @@ public class VisitService {
       } else {
         throw new BusinessException(
             String.format("Visit in service point %s does not exist", servicePointId),
+            String.format("Визит в точке обслуживания %s отсутствует", servicePointId),
             eventService,
             HttpStatus.NOT_FOUND);
       }
     } else {
       throw new BusinessException(
           String.format("Service point %s does not exist", servicePointId),
+          String.format("Точка обслуживания %s не существует", servicePointId),
           eventService,
           HttpStatus.NOT_FOUND);
     }
@@ -2018,7 +2074,8 @@ public class VisitService {
       visit = branchService.getBranch(branchId).getAllVisits().get(visit.getId());
       return visit;
     } else {
-      throw new BusinessException("Visit not found", eventService, HttpStatus.NOT_FOUND);
+      throw new BusinessException(
+          "Visit not found", "Визит не найден", eventService, HttpStatus.NOT_FOUND);
     }
   }
 
@@ -2083,17 +2140,19 @@ public class VisitService {
               visit.getParameterMap().get("LastQueueId"),
               returnTimeDelay);
         } else {
-          throw new BusinessException("Visit cannot be transferred", eventService, HttpStatus.CONFLICT);
+          throw new BusinessException("Visit cannot be transferred", "Визит нельзя перевести", eventService, HttpStatus.CONFLICT);
         }
       } else {
         throw new BusinessException(
             String.format("Visit in service point %s does not exist", servicePointId),
+            String.format("Визит в точке обслуживания %s отсутствует", servicePointId),
             eventService,
             HttpStatus.NOT_FOUND);
       }
     } else {
       throw new BusinessException(
           String.format("Service point %s does not exist", servicePointId),
+          String.format("Точка обслуживания %s не существует", servicePointId),
           eventService,
           HttpStatus.NOT_FOUND);
     }
@@ -2127,7 +2186,7 @@ public class VisitService {
         } else {
 
           throw new BusinessException(
-              "Queue not found in branch configuration", eventService, HttpStatus.NOT_FOUND);
+              "Queue not found in branch configuration", "Очередь не найдена в конфигурации отделения", eventService, HttpStatus.NOT_FOUND);
         }
         if (!isAppend) {
           visit.getParameterMap().put("isTransferredToStart", "true");
@@ -2192,12 +2251,14 @@ public class VisitService {
       } else {
         throw new BusinessException(
             String.format("Visit in service point %s does not exist", servicePointId),
+            String.format("Визит в точке обслуживания %s отсутствует", servicePointId),
             eventService,
             HttpStatus.NOT_FOUND);
       }
     } else {
       throw new BusinessException(
           String.format("Service point %s does not exist", servicePointId),
+          String.format("Точка обслуживания %s не существует", servicePointId),
           eventService,
           HttpStatus.NOT_FOUND);
     }
@@ -2227,7 +2288,7 @@ public class VisitService {
         } else {
 
           throw new BusinessException(
-              "Queue not found in branch configuration", eventService, HttpStatus.NOT_FOUND);
+              "Queue not found in branch configuration", "Очередь не найдена в конфигурации отделения", eventService, HttpStatus.NOT_FOUND);
         }
 
         assert queue != null;
@@ -2263,12 +2324,14 @@ public class VisitService {
       } else {
         throw new BusinessException(
             String.format("Visit in service point %s does not exist", servicePointId),
+            String.format("Визит в точке обслуживания %s отсутствует", servicePointId),
             eventService,
             HttpStatus.NOT_FOUND);
       }
     } else {
       throw new BusinessException(
           String.format("Service point %s does not exist", servicePointId),
+          String.format("Точка обслуживания %s не существует", servicePointId),
           eventService,
           HttpStatus.NOT_FOUND);
     }
@@ -2299,7 +2362,7 @@ public class VisitService {
         } else {
 
           throw new BusinessException(
-              "Service point not found in branch configuration",
+              "Service point not found in branch configuration", "Точка обслуживания не найдена в конфигурации отделения",
               eventService,
               HttpStatus.NOT_FOUND);
         }
@@ -2352,12 +2415,14 @@ public class VisitService {
       } else {
         throw new BusinessException(
             String.format("Visit in service point %s does not exist", servicePointId),
+            String.format("Визит в точке обслуживания %s отсутствует", servicePointId),
             eventService,
             HttpStatus.NOT_FOUND);
       }
     } else {
       throw new BusinessException(
           String.format("Service point %s does not exist", servicePointId),
+          String.format("Точка обслуживания %s не существует", servicePointId),
           eventService,
           HttpStatus.NOT_FOUND);
     }
@@ -2385,18 +2450,21 @@ public class VisitService {
         } else {
           throw new BusinessException(
               String.format("Visit in service point %s cannot be returned to the queue", servicePointId),
+              String.format("Визит в точке обслуживания %s нельзя вернуть в очередь", servicePointId),
               eventService,
               HttpStatus.NOT_FOUND);
         }
       } else {
         throw new BusinessException(
             String.format("Visit in service point %s does not exist", servicePointId),
+            String.format("Визит в точке обслуживания %s отсутствует", servicePointId),
             eventService,
             HttpStatus.NOT_FOUND);
       }
     }
     throw new BusinessException(
         String.format("Visit in service point %s cannot be returned to the queue", servicePointId),
+        String.format("Визит в точке обслуживания %s нельзя вернуть в очередь", servicePointId),
         eventService,
         HttpStatus.NOT_FOUND);
   }
@@ -2417,17 +2485,21 @@ public class VisitService {
       } else {
         if (servicePoint.getVisit() == null) {
           throw new BusinessException(
-              "Visit in service point " + servicePointId + " does not exist",
+              String.format("Visit in service point %s does not exist", servicePointId),
+              String.format("Визит в точке обслуживания %s отсутствует", servicePointId),
               eventService,
               HttpStatus.NOT_FOUND);
         } else {
-          throw new BusinessException("User does not exist", eventService, HttpStatus.NOT_FOUND);
+          throw new BusinessException("User does not exist", "Пользователь не существует", eventService, HttpStatus.NOT_FOUND);
         }
       }
 
     } else {
       throw new BusinessException(
-          "Service point " + servicePointId + " does not exist", eventService, HttpStatus.NOT_FOUND);
+          String.format("Service point %s does not exist", servicePointId),
+          String.format("Точка обслуживания %s не существует", servicePointId),
+          eventService,
+          HttpStatus.NOT_FOUND);
     }
   }
 
@@ -2456,7 +2528,7 @@ public class VisitService {
         } else {
 
           throw new BusinessException(
-              "User not found in branch configuration", eventService, HttpStatus.NOT_FOUND);
+              "User not found in branch configuration", "Пользователь не найден в конфигурации отделения", eventService, HttpStatus.NOT_FOUND);
         }
 
         User staff;
@@ -2465,7 +2537,7 @@ public class VisitService {
           staff = currentBranch.getServicePoints().get(servicePointId).getUser();
         } else {
           throw new BusinessException(
-              "User not found in branch configuration", eventService, HttpStatus.NOT_FOUND);
+              "User not found in branch configuration", "Пользователь не найден в конфигурации отделения", eventService, HttpStatus.NOT_FOUND);
         }
         VisitEvent event = VisitEvent.STOP_SERVING;
         event.getParameters().clear();
@@ -2507,12 +2579,14 @@ public class VisitService {
       } else {
         throw new BusinessException(
             String.format("Visit in service point %s does not exist", servicePointId),
+            String.format("Визит в точке обслуживания %s отсутствует", servicePointId),
             eventService,
             HttpStatus.NOT_FOUND);
       }
     } else {
       throw new BusinessException(
           String.format("Service point %s does not exist", servicePointId),
+          String.format("Точка обслуживания %s не существует", servicePointId),
           eventService,
           HttpStatus.NOT_FOUND);
     }
@@ -2546,7 +2620,7 @@ public class VisitService {
     } else {
 
       throw new BusinessException(
-          "Queue not found in branch configuration", eventService, HttpStatus.NOT_FOUND);
+          "Queue not found in branch configuration", "Очередь не найдена в конфигурации отделения", eventService, HttpStatus.NOT_FOUND);
     }
     User user;
     if (currentBranch.getServicePoints().containsKey(servicePointId)
@@ -2554,7 +2628,7 @@ public class VisitService {
       user = currentBranch.getServicePoints().get(servicePointId).getUser();
     } else {
       throw new BusinessException(
-          "User not found in branch configuration", eventService, HttpStatus.NOT_FOUND);
+          "User not found in branch configuration", "Пользователь не найден в конфигурации отделения", eventService, HttpStatus.NOT_FOUND);
     }
     visit.setServicePointId(null);
     visit.setPoolUserId(null);
@@ -2636,7 +2710,7 @@ public class VisitService {
       user = currentBranch.getServicePoints().get(servicePointId).getUser();
     } else {
       throw new BusinessException(
-          "User not found in branch configuration", eventService, HttpStatus.NOT_FOUND);
+          "User not found in branch configuration", "Пользователь не найден в конфигурации отделения", eventService, HttpStatus.NOT_FOUND);
     }
     Queue queue;
     if (currentBranch.getQueues().containsKey(queueId)) {
@@ -2644,7 +2718,7 @@ public class VisitService {
     } else {
 
       throw new BusinessException(
-          "Queue not found in branch configuration", eventService, HttpStatus.NOT_FOUND);
+          "Queue not found in branch configuration", "Очередь не найдена в конфигурации отделения", eventService, HttpStatus.NOT_FOUND);
     }
     visit.setTransferDateTime(ZonedDateTime.now());
     visit.setTransferTimeDelay(transferTimeDelay);
@@ -2769,7 +2843,7 @@ public class VisitService {
     } else {
 
       throw new BusinessException(
-          "Queue not found in branch configuration", eventService, HttpStatus.NOT_FOUND);
+          "Queue not found in branch configuration", "Очередь не найдена в конфигурации отделения", eventService, HttpStatus.NOT_FOUND);
     }
 
     if (visit.getServicePointId() != null) {
@@ -2857,7 +2931,7 @@ public class VisitService {
       user = currentBranch.getServicePoints().get(servicePointId).getUser();
     } else {
       throw new BusinessException(
-          "User not found in branch configuration", eventService, HttpStatus.NOT_FOUND);
+          "User not found in branch configuration", "Пользователь не найден в конфигурации отделения", eventService, HttpStatus.NOT_FOUND);
     }
     ServicePoint poolServicePoint;
     if (currentBranch.getServicePoints().containsKey(poolServicePointId)) {
@@ -2865,7 +2939,7 @@ public class VisitService {
     } else {
 
       throw new BusinessException(
-          "Queue not found in branch configuration", eventService, HttpStatus.NOT_FOUND);
+          "Queue not found in branch configuration", "Очередь не найдена в конфигурации отделения", eventService, HttpStatus.NOT_FOUND);
     }
 
     visit.setQueueId(null);
@@ -2938,7 +3012,7 @@ public class VisitService {
     Branch currentBranch = branchService.getBranch(branchId);
     String oldQueueID = visit.getQueueId();
     //    if (visit.getQueueId().isBlank()) {
-    //      throw new BusinessException("Visit is not in the queue", eventService);
+    //      throw new BusinessException("Visit is not in the queue", "Визит отсутствует в очереди", eventService);
     //    }
 
     ServicePoint poolServicePoint;
@@ -2947,7 +3021,7 @@ public class VisitService {
     } else {
 
       throw new BusinessException(
-          "Service point not found in branch configuration", eventService, HttpStatus.NOT_FOUND);
+          "Service point not found in branch configuration", "Точка обслуживания не найдена в конфигурации отделения", eventService, HttpStatus.NOT_FOUND);
     }
 
     visit.setServicePointId(null);
@@ -3050,7 +3124,7 @@ public class VisitService {
     } else {
 
       throw new BusinessException(
-          "Service point not found in branch configuration", eventService, HttpStatus.NOT_FOUND);
+          "Service point not found in branch configuration", "Точка обслуживания не найдена в конфигурации отделения", eventService, HttpStatus.NOT_FOUND);
     }
     Optional<UserRepresentation> user = keyCloackClient.getUserBySid(sid);
     String staffName = "";
@@ -3158,7 +3232,7 @@ public class VisitService {
         .contains(userId)) {
 
       throw new BusinessException(
-          "User not found in branch configuration", eventService, HttpStatus.NOT_FOUND);
+          "User not found in branch configuration", "Пользователь не найден в конфигурации отделения", eventService, HttpStatus.NOT_FOUND);
     }
 
     visit.setQueueId(null);
@@ -3235,7 +3309,7 @@ public class VisitService {
         .contains(userId)) {
 
       throw new BusinessException(
-          "User not found in branch configuration", eventService, HttpStatus.NOT_FOUND);
+          "User not found in branch configuration", "Пользователь не найден в конфигурации отделения", eventService, HttpStatus.NOT_FOUND);
     }
     Optional<UserRepresentation> user = keyCloackClient.getUserBySid(sid);
     String staffName = "";
@@ -3311,7 +3385,7 @@ public class VisitService {
     if (!this.getAllWorkingUsers(branchId).containsKey(userId)) {
 
       throw new BusinessException(
-          "User not found in branch configuration", eventService, HttpStatus.NOT_FOUND);
+          "User not found in branch configuration", "Пользователь не найден в конфигурации отделения", eventService, HttpStatus.NOT_FOUND);
     }
     Optional<UserRepresentation> user = keyCloackClient.getUserBySid(sid);
     String staffName = "";
@@ -3510,13 +3584,16 @@ public class VisitService {
 
       } else {
         throw new BusinessException(
-            "Visit not found in ServicePoint ", eventService, HttpStatus.NOT_FOUND);
+            String.format("Visit not found in service point %s", servicePointId),
+            String.format("Визит в точке обслуживания %s не найден", servicePointId),
+            eventService,
+            HttpStatus.NOT_FOUND);
       }
 
     } else {
 
       throw new BusinessException(
-          "Service point not found in branch configuration", eventService, HttpStatus.NOT_FOUND);
+          "Service point not found in branch configuration", "Точка обслуживания не найдена в конфигурации отделения", eventService, HttpStatus.NOT_FOUND);
     }
   }
 
@@ -3547,7 +3624,7 @@ public class VisitService {
       servicePointName = servicePoint.getName();
       if (servicePoint.getVisit() != null) {
         throw new BusinessException(
-            "Visit is already called in the service point", eventService, HttpStatus.CONFLICT);
+            "Visit is already called in the service point", "Визит уже вызван в точке обслуживания", eventService, HttpStatus.CONFLICT);
       }
       visit.setServicePointId(servicePointId);
       visit.setUserName(servicePoint.getUser() != null ? servicePoint.getUser().getName() : null);
@@ -3558,7 +3635,7 @@ public class VisitService {
       if (!servicePointId.isEmpty()
           && !currentBranch.getServicePoints().containsKey(servicePointId)) {
         throw new BusinessException(
-            "Service point not found in branch configuration", eventService, HttpStatus.NOT_FOUND);
+            "Service point not found in branch configuration", "Точка обслуживания не найдена в конфигурации отделения", eventService, HttpStatus.NOT_FOUND);
       }
     }
     VisitEvent event = VisitEvent.CALLED;
@@ -3574,7 +3651,7 @@ public class VisitService {
         currentBranch.getQueues().put(queue.get().getId(), queue.get());
       } else {
         throw new BusinessException(
-            "Queue not found in branch configuration or not available for the current work profile",
+            "Queue not found in branch configuration or not available for the current work profile", "Очередь не найдена в конфигурации отделения или недоступна для текущего рабочего профиля",
             eventService,
             HttpStatus.NOT_FOUND);
       }
@@ -3818,7 +3895,7 @@ public class VisitService {
       ServicePoint servicePoint = currentBranch.getServicePoints().get(servicePointId);
       if (servicePoint.getVisit() != null) {
         throw new BusinessException(
-            "Visit is already called in the service point", eventService, HttpStatus.CONFLICT);
+            "Visit is already called in the service point", "Визит уже вызван в точке обслуживания", eventService, HttpStatus.CONFLICT);
       }
       visit.setServicePointId(servicePointId);
 
@@ -3830,7 +3907,7 @@ public class VisitService {
       if (!servicePointId.isEmpty()
           && !currentBranch.getServicePoints().containsKey(servicePointId)) {
         throw new BusinessException(
-            "Service point not found in branch configuration", eventService, HttpStatus.NOT_FOUND);
+            "Service point not found in branch configuration", "Точка обслуживания не найдена в конфигурации отделения", eventService, HttpStatus.NOT_FOUND);
       }
     }
 
@@ -3998,7 +4075,7 @@ public class VisitService {
 
     } else {
       throw new BusinessException(
-          "User is not logged into the service point", eventService, HttpStatus.FORBIDDEN);
+          "User is not logged into the service point", "Пользователь не авторизован в точке обслуживания", eventService, HttpStatus.FORBIDDEN);
     }
     if (currentBranch.getParameterMap().containsKey("autoCallMode")
         && currentBranch.getParameterMap().get("autoCallMode").toString().equals("true")) {
@@ -4006,7 +4083,7 @@ public class VisitService {
       servicePoint.setAutoCallMode(true);
       currentBranch.getServicePoints().put(servicePoint.getId(), servicePoint);
       branchService.add(currentBranch.getId(), currentBranch);
-      throw new BusinessException("Automatic call mode is enabled", eventService, HttpStatus.valueOf(207));
+      throw new BusinessException("Automatic call mode is enabled", "Автоматический режим вызова включён", eventService, HttpStatus.valueOf(207));
     }
     return Optional.empty();
   }
@@ -4063,7 +4140,7 @@ public class VisitService {
 
     } else {
       throw new BusinessException(
-          "User is not logged into the service point", eventService, HttpStatus.FORBIDDEN);
+          "User is not logged into the service point", "Пользователь не авторизован в точке обслуживания", eventService, HttpStatus.FORBIDDEN);
     }
     if (currentBranch.getParameterMap().containsKey("autoCallMode")
         && currentBranch.getParameterMap().get("autoCallMode").toString().equals("true")) {
@@ -4071,7 +4148,7 @@ public class VisitService {
       servicePoint.setAutoCallMode(true);
       currentBranch.getServicePoints().put(servicePoint.getId(), servicePoint);
       branchService.add(currentBranch.getId(), currentBranch);
-      throw new BusinessException("Automatic call mode is enabled", eventService, HttpStatus.valueOf(207));
+      throw new BusinessException("Automatic call mode is enabled", "Автоматический режим вызова включён", eventService, HttpStatus.valueOf(207));
     }
     return Optional.empty();
   }
@@ -4127,7 +4204,7 @@ public class VisitService {
 
     } else {
       throw new BusinessException(
-          "User is not logged into the service point", eventService, HttpStatus.FORBIDDEN);
+          "User is not logged into the service point", "Пользователь не авторизован в точке обслуживания", eventService, HttpStatus.FORBIDDEN);
     }
     if (currentBranch.getParameterMap().containsKey("autoCallMode")
         && currentBranch.getParameterMap().get("autoCallMode").toString().equals("true")) {
@@ -4135,7 +4212,7 @@ public class VisitService {
       servicePoint.setAutoCallMode(true);
       currentBranch.getServicePoints().put(servicePoint.getId(), servicePoint);
       branchService.add(currentBranch.getId(), currentBranch);
-      throw new BusinessException("Automatic call mode is enabled", eventService, HttpStatus.valueOf(207));
+      throw new BusinessException("Automatic call mode is enabled", "Автоматический режим вызова включён", eventService, HttpStatus.valueOf(207));
     }
     return Optional.empty();
   }
@@ -4176,6 +4253,7 @@ public class VisitService {
     if (!currentBranch.getServicePoints().containsKey(servicePointId)) {
       throw new BusinessException(
           String.format("Service point %s not found", servicePointId),
+          String.format("Точка обслуживания %s не найдена", servicePointId),
           eventService,
           HttpStatus.NOT_FOUND);
     }
@@ -4202,6 +4280,9 @@ public class VisitService {
           String.format(
               "Service point %s cannot be turned on because automatic call mode is disabled for the current branch",
               servicePointId),
+          String.format(
+              "Точку обслуживания %s нельзя включить, потому что режим автовызова отключён для текущего филиала",
+              servicePointId),
           eventService,
           HttpStatus.CONFLICT);
     } else {
@@ -4224,6 +4305,7 @@ public class VisitService {
     if (!currentBranch.getServicePoints().containsKey(servicePointId)) {
       throw new BusinessException(
           String.format("Service point %s not found", servicePointId),
+          String.format("Точка обслуживания %s не найдена", servicePointId),
           eventService,
           HttpStatus.NOT_FOUND);
     }
@@ -4324,7 +4406,7 @@ public class VisitService {
 
     } else {
       throw new BusinessException(
-          "User is not logged into the service point", eventService, HttpStatus.FORBIDDEN);
+          "User is not logged into the service point", "Пользователь не авторизован в точке обслуживания", eventService, HttpStatus.FORBIDDEN);
     }
     if (currentBranch.getParameterMap().containsKey("autoCallMode")
         && currentBranch.getParameterMap().get("autoCallMode").toString().equals("true")) {
@@ -4350,7 +4432,7 @@ public class VisitService {
               .body(servicePoint)
               .build();
       eventService.send("frontend", false, autocallEvent);
-      throw new BusinessException("Automatic call mode is enabled", eventService, HttpStatus.valueOf(207));
+      throw new BusinessException("Automatic call mode is enabled", "Автоматический режим вызова включён", eventService, HttpStatus.valueOf(207));
     }
   }
 
@@ -4409,12 +4491,12 @@ public class VisitService {
 
       } else {
         throw new BusinessException(
-            "User is not logged into the service point", eventService, HttpStatus.FORBIDDEN);
+            "User is not logged into the service point", "Пользователь не авторизован в точке обслуживания", eventService, HttpStatus.FORBIDDEN);
       }
 
     } else {
       throw new BusinessException(
-          "Service point not found in branch configuration", eventService, HttpStatus.NOT_FOUND);
+          "Service point not found in branch configuration", "Точка обслуживания не найдена в конфигурации отделения", eventService, HttpStatus.NOT_FOUND);
     }
     if (currentBranch.getParameterMap().containsKey("autoCallMode")
         && currentBranch.getParameterMap().get("autoCallMode").toString().equals("true")) {
@@ -4449,12 +4531,12 @@ public class VisitService {
 
       } else {
         throw new BusinessException(
-            "User is not logged into the service point", eventService, HttpStatus.FORBIDDEN);
+            "User is not logged into the service point", "Пользователь не авторизован в точке обслуживания", eventService, HttpStatus.FORBIDDEN);
       }
 
     } else {
       throw new BusinessException(
-          "Service point not found in branch configuration", eventService, HttpStatus.NOT_FOUND);
+          "Service point not found in branch configuration", "Точка обслуживания не найдена в конфигурации отделения", eventService, HttpStatus.NOT_FOUND);
     }
     if (currentBranch.getParameterMap().containsKey("autoCallMode")
         && currentBranch.getParameterMap().get("autoCallMode").toString().equals("true")) {
@@ -4486,12 +4568,12 @@ public class VisitService {
 
       } else {
         throw new BusinessException(
-            "User is not logged into the service point", eventService, HttpStatus.FORBIDDEN);
+            "User is not logged into the service point", "Пользователь не авторизован в точке обслуживания", eventService, HttpStatus.FORBIDDEN);
       }
 
     } else {
       throw new BusinessException(
-          "Service point not found in branch configuration", eventService, HttpStatus.NOT_FOUND);
+          "Service point not found in branch configuration", "Точка обслуживания не найдена в конфигурации отделения", eventService, HttpStatus.NOT_FOUND);
     }
     if (currentBranch.getParameterMap().containsKey("autoCallMode")
         && currentBranch.getParameterMap().get("autoCallMode").toString().equals("true")) {
@@ -4525,12 +4607,12 @@ public class VisitService {
 
       } else {
         throw new BusinessException(
-            "User is not logged into the service point", eventService, HttpStatus.FORBIDDEN);
+            "User is not logged into the service point", "Пользователь не авторизован в точке обслуживания", eventService, HttpStatus.FORBIDDEN);
       }
 
     } else {
       throw new BusinessException(
-          "Service point not found in branch configuration", eventService, HttpStatus.NOT_FOUND);
+          "Service point not found in branch configuration", "Точка обслуживания не найдена в конфигурации отделения", eventService, HttpStatus.NOT_FOUND);
     }
     if (currentBranch.getParameterMap().containsKey("autoCallMode")
         && currentBranch.getParameterMap().get("autoCallMode").toString().equals("true")) {
@@ -4549,12 +4631,18 @@ public class VisitService {
 
     if (visit.getReturningTime() > 0 && visit.getReturningTime() < visit.getReturnTimeDelay()) {
       throw new BusinessException(
-          "You cannot delete a visit that has just returned", eventService, HttpStatus.CONFLICT);
+          "You cannot delete a visit that has just returned",
+          "Нельзя удалить визит, который только что вернулся",
+          eventService,
+          HttpStatus.CONFLICT);
     }
     if (visit.getTransferingTime() > 0
         && visit.getTransferingTime() < visit.getTransferTimeDelay()) {
       throw new BusinessException(
-          "You cannot delete a visit that has just been transferred", eventService, HttpStatus.CONFLICT);
+          "You cannot delete a visit that has just been transferred",
+          "Нельзя удалить визит, который только что был переведён",
+          eventService,
+          HttpStatus.CONFLICT);
     }
     visit.setServicePointId(null);
     visit.setQueueId(null);
@@ -4582,7 +4670,7 @@ public class VisitService {
         } else {
 
           throw new BusinessException(
-              "User not found in branch configuration", eventService, HttpStatus.NOT_FOUND);
+              "User not found in branch configuration", "Пользователь не найден в конфигурации отделения", eventService, HttpStatus.NOT_FOUND);
         }
         VisitEvent event = VisitEvent.STOP_SERVING;
         event.getParameters().put("isForced", "false");
@@ -4680,12 +4768,14 @@ public class VisitService {
       } else {
         throw new BusinessException(
             String.format("Visit in service point %s does not exist", servicePointId),
+            String.format("Визит в точке обслуживания %s отсутствует", servicePointId),
             eventService,
             HttpStatus.NOT_FOUND);
       }
     } else {
       throw new BusinessException(
           String.format("Service point %s does not exist", servicePointId),
+          String.format("Точка обслуживания %s не существует", servicePointId),
           eventService,
           HttpStatus.NOT_FOUND);
     }
@@ -4706,7 +4796,7 @@ public class VisitService {
         } else {
 
           throw new BusinessException(
-              "Service point not found in branch configuration",
+              "Service point not found in branch configuration", "Точка обслуживания не найдена в конфигурации отделения",
               eventService,
               HttpStatus.NOT_FOUND);
         }
@@ -4810,12 +4900,14 @@ public class VisitService {
       } else {
         throw new BusinessException(
             String.format("Visit in service point %s does not exist", servicePointId),
+            String.format("Визит в точке обслуживания %s отсутствует", servicePointId),
             eventService,
             HttpStatus.NOT_FOUND);
       }
     } else {
       throw new BusinessException(
           String.format("Service point %s does not exist", servicePointId),
+          String.format("Точка обслуживания %s не существует", servicePointId),
           eventService,
           HttpStatus.NOT_FOUND);
     }
@@ -4840,7 +4932,7 @@ public class VisitService {
         } else {
 
           throw new BusinessException(
-              "Service point not found in branch configuration",
+              "Service point not found in branch configuration", "Точка обслуживания не найдена в конфигурации отделения",
               eventService,
               HttpStatus.NOT_FOUND);
         }
@@ -4944,12 +5036,14 @@ public class VisitService {
       } else {
         throw new BusinessException(
             String.format("Visit in service point %s does not exist", servicePointId),
+            String.format("Визит в точке обслуживания %s отсутствует", servicePointId),
             eventService,
             HttpStatus.NOT_FOUND);
       }
     } else {
       throw new BusinessException(
           String.format("Service point %s does not exist", servicePointId),
+          String.format("Точка обслуживания %s не существует", servicePointId),
           eventService,
           HttpStatus.NOT_FOUND);
     }
@@ -4984,7 +5078,7 @@ public class VisitService {
         Visit visit = servicePoint.getVisit();
         if (visit.getCurrentService() == null)
           throw new BusinessException(
-              "Current service is null", eventService, HttpStatus.NOT_FOUND);
+              "Current service is null", "Текущая услуга отсутствует", eventService, HttpStatus.NOT_FOUND);
 
         Mark note = new Mark();
         note.setId(UUID.randomUUID().toString());
@@ -5035,12 +5129,14 @@ public class VisitService {
       } else {
         throw new BusinessException(
             String.format("Visit in service point %s does not exist", servicePointId),
+            String.format("Визит в точке обслуживания %s отсутствует", servicePointId),
             eventService,
             HttpStatus.NOT_FOUND);
       }
     } else {
       throw new BusinessException(
           String.format("Service point %s does not exist", servicePointId),
+          String.format("Точка обслуживания %s не существует", servicePointId),
           eventService,
           HttpStatus.NOT_FOUND);
     }
@@ -5060,7 +5156,10 @@ public class VisitService {
       return visit.getVisitNotes();
     } else {
       throw new BusinessException(
-          String.format("Visit %s not found", visitId), eventService, HttpStatus.NOT_FOUND);
+          String.format("Visit %s not found", visitId),
+          String.format("Визит %s не найден", visitId),
+          eventService,
+          HttpStatus.NOT_FOUND);
     }
   }
 }

--- a/src/main/java/ru/aritmos/service/rules/MaxLifeTimeCallRule.java
+++ b/src/main/java/ru/aritmos/service/rules/MaxLifeTimeCallRule.java
@@ -74,7 +74,7 @@ public class MaxLifeTimeCallRule implements CallRule {
 
     } else {
       throw new BusinessException(
-          "User is not logged into the service point", eventService, HttpStatus.FORBIDDEN);
+          "User is not logged into the service point", "Пользователь не авторизован в точке обслуживания", eventService, HttpStatus.FORBIDDEN);
     }
     return Optional.empty();
   }
@@ -121,7 +121,7 @@ public class MaxLifeTimeCallRule implements CallRule {
 
     } else {
       throw new BusinessException(
-          "User is not logged into the service point", eventService, HttpStatus.FORBIDDEN);
+          "User is not logged into the service point", "Пользователь не авторизован в точке обслуживания", eventService, HttpStatus.FORBIDDEN);
     }
     return Optional.empty();
   }

--- a/src/main/java/ru/aritmos/service/rules/MaxWaitingTimeCallRule.java
+++ b/src/main/java/ru/aritmos/service/rules/MaxWaitingTimeCallRule.java
@@ -102,13 +102,13 @@ public class MaxWaitingTimeCallRule implements CallRule {
         return result;
       } else {
         throw new BusinessException(
-            "User has an incorrect work profile for the service point",
+            "User has an incorrect work profile for the service point", "У пользователя некорректный рабочий профиль для точки обслуживания",
             eventService,
             HttpStatus.FORBIDDEN);
       }
     }
     throw new BusinessException(
-        "User is not logged into the service point", eventService, HttpStatus.FORBIDDEN);
+        "User is not logged into the service point", "Пользователь не авторизован в точке обслуживания", eventService, HttpStatus.FORBIDDEN);
   }
 
   /**
@@ -150,7 +150,7 @@ public class MaxWaitingTimeCallRule implements CallRule {
 
     } else {
       throw new BusinessException(
-          "User is not logged into the service point", eventService, HttpStatus.FORBIDDEN);
+          "User is not logged into the service point", "Пользователь не авторизован в точке обслуживания", eventService, HttpStatus.FORBIDDEN);
     }
     return Optional.empty();
   }

--- a/src/main/java/ru/aritmos/service/rules/SegmentationRule.java
+++ b/src/main/java/ru/aritmos/service/rules/SegmentationRule.java
@@ -97,7 +97,7 @@ public class SegmentationRule {
           currentBranch.getCustomSegmentationRules().get(segmentationRuleId).toBuilder().build();
     } else {
       throw new BusinessException(
-          "Segmentation rule not found", eventService, HttpStatus.NOT_FOUND);
+          "Segmentation rule not found", "Правило сегментации не найдено", eventService, HttpStatus.NOT_FOUND);
     }
     Map<String, Object> inputParameters = groovyScript.getInputParameters();
     if (inputParameters.containsKey("visit") && inputParameters.containsKey("branch")) {
@@ -112,7 +112,7 @@ public class SegmentationRule {
       } else return Optional.empty();
     } else {
       throw new BusinessException(
-          "Input parameter visit or branch not found", eventService, HttpStatus.NOT_FOUND);
+          "Input parameter visit or branch not found", "Входной параметр визита или отделения не найден", eventService, HttpStatus.NOT_FOUND);
     }
   }
 

--- a/src/test/unit/java/ru/aritmos/exceptions/BusinessExceptionTest.java
+++ b/src/test/unit/java/ru/aritmos/exceptions/BusinessExceptionTest.java
@@ -20,10 +20,12 @@ class BusinessExceptionTest {
 
         HttpStatusException thrown = assertThrows(
                 HttpStatusException.class,
-                () -> new BusinessException("ошибка", eventService, HttpStatus.BAD_REQUEST)
+                () ->
+                    new BusinessException(
+                        "Error occurred", "Произошла ошибка", eventService, HttpStatus.BAD_REQUEST)
         );
         assertEquals(HttpStatus.BAD_REQUEST, thrown.getStatus());
-        assertEquals("ошибка", thrown.getMessage());
+        assertEquals("Error occurred", thrown.getMessage());
 
         ArgumentCaptor<Event> captor = ArgumentCaptor.forClass(Event.class);
         verify(eventService).send(eq("*"), eq(false), captor.capture());
@@ -36,9 +38,11 @@ class BusinessExceptionTest {
 
         HttpStatusException thrown = assertThrows(
                 HttpStatusException.class,
-                () -> new BusinessException("client", "log", eventService, HttpStatus.CONFLICT)
+                () ->
+                    new BusinessException(
+                        "Client message", "Сообщение для лога", eventService, HttpStatus.CONFLICT)
         );
-        assertEquals("client", thrown.getMessage());
+        assertEquals("Client message", thrown.getMessage());
         assertEquals(HttpStatus.CONFLICT, thrown.getStatus());
 
         ArgumentCaptor<Event> captor = ArgumentCaptor.forClass(Event.class);
@@ -54,7 +58,9 @@ class BusinessExceptionTest {
 
         HttpStatusException thrown = assertThrows(
                 HttpStatusException.class,
-                () -> new BusinessException(new Object(), eventService, HttpStatus.I_AM_A_TEAPOT, mapper)
+                () ->
+                    new BusinessException(
+                        new Object(), "Сообщение для лога", eventService, HttpStatus.I_AM_A_TEAPOT, mapper)
         );
         assertEquals(HttpStatus.I_AM_A_TEAPOT, thrown.getStatus());
 
@@ -71,7 +77,9 @@ class BusinessExceptionTest {
 
         HttpStatusException thrown = assertThrows(
                 HttpStatusException.class,
-                () -> new BusinessException(body, "log", eventService, HttpStatus.NOT_FOUND)
+                () ->
+                    new BusinessException(
+                        body, "Сообщение для лога", eventService, HttpStatus.NOT_FOUND)
         );
         assertEquals(HttpStatus.NOT_FOUND, thrown.getStatus());
 
@@ -86,9 +94,15 @@ class BusinessExceptionTest {
 
         HttpStatusException thrown = assertThrows(
                 HttpStatusException.class,
-                () -> new BusinessException("client", "log", "event", eventService, HttpStatus.BAD_REQUEST)
+                () ->
+                    new BusinessException(
+                        "Client message",
+                        "Сообщение для лога",
+                        "Event payload",
+                        eventService,
+                        HttpStatus.BAD_REQUEST)
         );
-        assertEquals("client", thrown.getMessage());
+        assertEquals("Client message", thrown.getMessage());
         assertEquals(HttpStatus.BAD_REQUEST, thrown.getStatus());
 
         ArgumentCaptor<Event> captor = ArgumentCaptor.forClass(Event.class);


### PR DESCRIPTION
## Изменения
- переработан `BusinessException`, чтобы HTTP-ответ всегда содержал англоязычное сообщение, лог — русскоязычное, а событие — корректное описание ошибки
- дописаны двуязычные тексты для запрета удаления визита сразу после возврата или перевода
- обновлены модульные тесты `BusinessExceptionTest` под новую сигнатуру и тексты сообщений

## Тестирование
- `mvn -s .mvn/settings.xml test` *(падает: нет доступа к Maven Central для загрузки родительского POM)*

------
https://chatgpt.com/codex/tasks/task_e_68d42074c6b88328943c830906cec4d7