### PR TITLE
fix(maven): отключить прокси по умолчанию

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,5 +1,2 @@
 -s=.mvn/settings.xml
--Dmaven.proxy.active=true
--Dmaven.proxy.host=proxy
--Dmaven.proxy.port=8080
--Dmaven.proxy.nonProxyHosts=localhost|127.0.0.1|::1
+-Dmaven.proxy.active=false


### PR DESCRIPTION
## Summary
- отключен принудительный прокси в `.mvn/maven.config`, чтобы Maven мог напрямую подтягивать родительский POM и зависимости
- оставлена возможность включить прокси при необходимости через системные свойства

## Testing
- mvn -s .mvn/settings.xml -version

------
https://chatgpt.com/codex/tasks/task_e_68d42b58a71083289d9714c59c456bb5