### PR TITLE
fix: задаю кодировку UTF-8 для логов

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -4,6 +4,7 @@
         <!-- encoders are assigned the type
              ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
         <encoder>
+            <charset>UTF-8</charset>
             <pattern>%cyan(%d{HH:mm:ss.SSS}) %gray([%thread]) %highlight(%-5level) %magenta(%logger{36}) - %msg%n</pattern>
         </encoder>
     </appender>


### PR DESCRIPTION
## Summary
- добавил явное указание кодировки UTF-8 для консольного энкодера Logback, чтобы кириллические сообщения не превращались в нечитаемые символы

## Testing
- `mvn -s .mvn/settings.xml test` *(не выполнено: репозиторий зависимостей недоступен из окружения CI)*

------
https://chatgpt.com/codex/tasks/task_e_68d42ccaedf883288a4ed255dc31b426