### PR TITLE
Настройка Maven для работы за прокси

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,1 +1,6 @@
 -Djava.net.preferIPv4Stack=true
+-Dhttp.proxyHost=proxy
+-Dhttp.proxyPort=8080
+-Dhttps.proxyHost=proxy
+-Dhttps.proxyPort=8080
+-Dhttp.nonProxyHosts=localhost|127.0.0.1|::1

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,2 +1,1 @@
 -s=.mvn/settings.xml
--Dmaven.proxy.active=false

--- a/.mvn/settings.xml
+++ b/.mvn/settings.xml
@@ -4,19 +4,19 @@
   <proxies>
     <proxy>
       <id>default-http</id>
-      <active>${maven.proxy.active}</active>
+      <active>true</active>
       <protocol>http</protocol>
-      <host>${maven.proxy.host}</host>
-      <port>${maven.proxy.port}</port>
-      <nonProxyHosts>${maven.proxy.nonProxyHosts}</nonProxyHosts>
+      <host>proxy</host>
+      <port>8080</port>
+      <nonProxyHosts>localhost|127.0.0.1|::1</nonProxyHosts>
     </proxy>
     <proxy>
       <id>default-https</id>
-      <active>${maven.proxy.active}</active>
+      <active>true</active>
       <protocol>https</protocol>
-      <host>${maven.proxy.host}</host>
-      <port>${maven.proxy.port}</port>
-      <nonProxyHosts>${maven.proxy.nonProxyHosts}</nonProxyHosts>
+      <host>proxy</host>
+      <port>8080</port>
+      <nonProxyHosts>localhost|127.0.0.1|::1</nonProxyHosts>
     </proxy>
   </proxies>
 </settings>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@
 - Запуск JAR: `java -jar target/visitmanager.jar`.
 - Запуск в dev (если подключен плагин): `mvn -s .mvn/settings.xml mn:run`.
 - Тесты: `mvn -s .mvn/settings.xml test`.
+- Сетевое окружение использует обязательный HTTP(S)-прокси `proxy:8080`; параметры уже прописаны в `.mvn/jvm.config` и `.mvn/settings.xml`. При работе вне текущей инфраструктуры обновляйте `proxy`, `port` и `nonProxyHosts` в этих файлах или задавайте собственные значения через `JAVA_TOOL_OPTIONS`/`MAVEN_OPTS` перед запуском Maven.
 - Локально в Docker: `docker compose -f docker-compose.local.yml up -d --build`; остановка — `docker compose -f docker-compose.local.yml down`.
 
 ## Стиль кодирования и соглашения


### PR DESCRIPTION
## Summary
- включил системные HTTP(S)-прокси в конфигурации Maven, чтобы сборка проходила в изолированной сети
- избавился от предупреждений о некорректных placeholder-значениях и упростил передачу настроек через maven.config
- задокументировал требования к прокси в AGENTS.md для дальнейших изменений

## Testing
- mvn -s .mvn/settings.xml test *(падает: серия существующих тестов ожидает сообщения об ошибках, а сервис возвращает null)*

------
https://chatgpt.com/codex/tasks/task_e_68d42e0646c88328b1f56d861a53a6c8