### PR TITLE
feat: добавить локализацию сообщений BusinessException

### DIFF
--- a/src/main/java/ru/aritmos/exceptions/BusinessExceptionLocalization.java
+++ b/src/main/java/ru/aritmos/exceptions/BusinessExceptionLocalization.java
@@ -1,0 +1,124 @@
+package ru.aritmos.exceptions;
+
+import io.micronaut.core.annotation.Nullable;
+import jakarta.inject.Singleton;
+import java.util.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Сервис локализации сообщений {@link BusinessException} на основе настроек.
+ */
+@Singleton
+public class BusinessExceptionLocalization {
+
+  private static final Logger LOG = LoggerFactory.getLogger(BusinessExceptionLocalization.class);
+
+  private final BusinessExceptionLocalizationProperties properties;
+
+  public BusinessExceptionLocalization(BusinessExceptionLocalizationProperties properties) {
+    this.properties = Objects.requireNonNull(properties, "Настройки локализации не заданы");
+  }
+
+  /**
+   * Создать локализацию с настройками по умолчанию.
+   */
+  public static BusinessExceptionLocalization defaultLocalization() {
+    return new BusinessExceptionLocalization(new BusinessExceptionLocalizationProperties());
+  }
+
+  /**
+   * Применить локализацию для финальных сообщений исключения.
+   *
+   * @param responseBody тело ответа, отправляемое клиенту
+   * @param clientMessage сообщение для клиента
+   * @param logMessage сообщение для лога
+   * @param eventMessage сообщение для события
+   * @return локализованные значения
+   */
+  public LocalizedMessages localize(
+      @Nullable Object responseBody,
+      @Nullable String clientMessage,
+      @Nullable String logMessage,
+      @Nullable String eventMessage) {
+
+    String localizedClient = localizeHttp(clientMessage);
+    Object localizedResponse = localizeResponseBody(responseBody, localizedClient);
+    String localizedLog = localizeLog(logMessage);
+    String localizedEvent = localizeEvent(eventMessage);
+    return new LocalizedMessages(localizedResponse, localizedClient, localizedLog, localizedEvent);
+  }
+
+  private Object localizeResponseBody(@Nullable Object responseBody, @Nullable String localizedClient) {
+    if (responseBody instanceof CharSequence sequence) {
+      return localizeHttp(sequence.toString());
+    }
+    if (responseBody == null) {
+      return localizedClient;
+    }
+    return responseBody;
+  }
+
+  private String localizeHttp(@Nullable String message) {
+    return properties.getHttp().resolve(message);
+  }
+
+  private String localizeLog(@Nullable String message) {
+    BusinessExceptionLocalizationProperties.ChannelLocalization channel = properties.getLog();
+    String localized = channel.resolve(message);
+    if (localized == null && message != null) {
+      LOG.warn("Не удалось локализовать сообщение лога '{}', используется исходный текст", message);
+    }
+    return localized;
+  }
+
+  private String localizeEvent(@Nullable String message) {
+    BusinessExceptionLocalizationProperties.ChannelLocalization channel = properties.getEvent();
+    String localized = channel.resolve(message);
+    if (localized == null && message != null) {
+      LOG.warn("Не удалось локализовать сообщение события '{}', используется исходный текст", message);
+    }
+    return localized;
+  }
+
+  /**
+   * Результат локализации сообщений.
+   */
+  public static final class LocalizedMessages {
+    private final Object responseBody;
+    private final String clientMessage;
+    private final String logMessage;
+    private final String eventMessage;
+
+    public LocalizedMessages(
+        @Nullable Object responseBody,
+        @Nullable String clientMessage,
+        @Nullable String logMessage,
+        @Nullable String eventMessage) {
+      this.responseBody = responseBody;
+      this.clientMessage = clientMessage;
+      this.logMessage = logMessage;
+      this.eventMessage = eventMessage;
+    }
+
+    @Nullable
+    public Object responseBody() {
+      return responseBody;
+    }
+
+    @Nullable
+    public String clientMessage() {
+      return clientMessage;
+    }
+
+    @Nullable
+    public String logMessage() {
+      return logMessage;
+    }
+
+    @Nullable
+    public String eventMessage() {
+      return eventMessage;
+    }
+  }
+}

--- a/src/main/java/ru/aritmos/exceptions/BusinessExceptionLocalizationConfigurer.java
+++ b/src/main/java/ru/aritmos/exceptions/BusinessExceptionLocalizationConfigurer.java
@@ -1,0 +1,22 @@
+package ru.aritmos.exceptions;
+
+import io.micronaut.context.annotation.Context;
+import jakarta.annotation.PostConstruct;
+
+/**
+ * Подключение настроек локализации к {@link BusinessException}.
+ */
+@Context
+public class BusinessExceptionLocalizationConfigurer {
+
+  private final BusinessExceptionLocalization localization;
+
+  public BusinessExceptionLocalizationConfigurer(BusinessExceptionLocalization localization) {
+    this.localization = localization;
+  }
+
+  @PostConstruct
+  void configure() {
+    BusinessException.configureLocalization(localization);
+  }
+}

--- a/src/main/java/ru/aritmos/exceptions/BusinessExceptionLocalizationProperties.java
+++ b/src/main/java/ru/aritmos/exceptions/BusinessExceptionLocalizationProperties.java
@@ -1,0 +1,152 @@
+package ru.aritmos.exceptions;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Настройки локализации сообщений {@link BusinessException}.
+ */
+@ConfigurationProperties("business-exception.localization")
+public class BusinessExceptionLocalizationProperties {
+
+  private ChannelLocalization http = ChannelLocalization.httpDefaults();
+  private ChannelLocalization log = ChannelLocalization.logDefaults();
+  private ChannelLocalization event = ChannelLocalization.eventDefaults();
+
+  public ChannelLocalization getHttp() {
+    return http;
+  }
+
+  public void setHttp(ChannelLocalization http) {
+    this.http = http != null ? http : ChannelLocalization.httpDefaults();
+  }
+
+  public ChannelLocalization getLog() {
+    return log;
+  }
+
+  public void setLog(ChannelLocalization log) {
+    this.log = log != null ? log : ChannelLocalization.logDefaults();
+  }
+
+  public ChannelLocalization getEvent() {
+    return event;
+  }
+
+  public void setEvent(ChannelLocalization event) {
+    this.event = event != null ? event : ChannelLocalization.eventDefaults();
+  }
+
+  /**
+   * Настройки отдельного канала сообщений.
+   */
+  public static final class ChannelLocalization {
+
+    private String language;
+    private String defaultLanguage;
+    private Map<String, Map<String, String>> messages = new LinkedHashMap<>();
+
+    public static ChannelLocalization httpDefaults() {
+      ChannelLocalization localization = new ChannelLocalization();
+      localization.setLanguage("en");
+      localization.setDefaultLanguage("en");
+      return localization;
+    }
+
+    public static ChannelLocalization logDefaults() {
+      ChannelLocalization localization = new ChannelLocalization();
+      localization.setLanguage("ru");
+      localization.setDefaultLanguage("ru");
+      return localization;
+    }
+
+    public static ChannelLocalization eventDefaults() {
+      ChannelLocalization localization = new ChannelLocalization();
+      localization.setLanguage("ru");
+      localization.setDefaultLanguage("ru");
+      return localization;
+    }
+
+    public String getLanguage() {
+      return language;
+    }
+
+    public void setLanguage(String language) {
+      this.language = normalizeLanguage(language);
+    }
+
+    public String getDefaultLanguage() {
+      return defaultLanguage;
+    }
+
+    public void setDefaultLanguage(String defaultLanguage) {
+      this.defaultLanguage = normalizeLanguage(defaultLanguage);
+    }
+
+    public Map<String, Map<String, String>> getMessages() {
+      return messages;
+    }
+
+    public void setMessages(Map<String, Map<String, String>> messages) {
+      if (messages == null) {
+        this.messages = new LinkedHashMap<>();
+        return;
+      }
+      Map<String, Map<String, String>> normalized = new LinkedHashMap<>();
+      for (Map.Entry<String, Map<String, String>> entry : messages.entrySet()) {
+        Map<String, String> translations = entry.getValue();
+        if (translations == null || translations.isEmpty()) {
+          normalized.put(entry.getKey(), Collections.emptyMap());
+          continue;
+        }
+        Map<String, String> normalizedTranslations = new LinkedHashMap<>();
+        for (Map.Entry<String, String> translation : translations.entrySet()) {
+          String languageKey = normalizeLanguage(translation.getKey());
+          if (languageKey != null) {
+            normalizedTranslations.put(languageKey, translation.getValue());
+          }
+        }
+        normalized.put(entry.getKey(), normalizedTranslations);
+      }
+      this.messages = normalized;
+    }
+
+    /**
+     * Найти перевод сообщения с учётом заданных языков.
+     *
+     * @param fallback текст по умолчанию
+     * @return локализованный текст или исходное значение, если перевод не найден
+     */
+    public String resolve(String fallback) {
+      if (fallback == null) {
+        return null;
+      }
+      String targetLanguage = language != null ? language : defaultLanguage;
+      if (targetLanguage == null) {
+        return fallback;
+      }
+      Map<String, String> translations = messages.getOrDefault(fallback, Collections.emptyMap());
+      String translation = translations.get(targetLanguage);
+      if (translation != null) {
+        return translation;
+      }
+      if (defaultLanguage != null) {
+        translation = translations.get(defaultLanguage);
+        if (translation != null) {
+          return translation;
+        }
+      }
+      return fallback;
+    }
+
+    private static String normalizeLanguage(String language) {
+      if (language == null || language.isBlank()) {
+        return null;
+      }
+      return language.trim().toLowerCase(Locale.ROOT);
+    }
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,6 +17,18 @@ graphql:
 loki:
   url: '${LOKI_SERVER:`http://192.168.3.13:3100/loki/api/v1/push`}'
 
+business-exception:
+  localization:
+    http:
+      language: '${BUSINESS_EXCEPTION_HTTP_LANG:`en`}'
+      default-language: en
+    log:
+      language: '${BUSINESS_EXCEPTION_LOG_LANG:`ru`}'
+      default-language: ru
+    event:
+      language: '${BUSINESS_EXCEPTION_EVENT_LANG:`ru`}'
+      default-language: ru
+
 
 micronaut:
   test:

--- a/src/test/unit/java/ru/aritmos/exceptions/BusinessExceptionLocalizationTest.java
+++ b/src/test/unit/java/ru/aritmos/exceptions/BusinessExceptionLocalizationTest.java
@@ -1,0 +1,83 @@
+package ru.aritmos.exceptions;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static ru.aritmos.test.LoggingAssertions.*;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.exceptions.HttpStatusException;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.slf4j.LoggerFactory;
+import ru.aritmos.events.model.Event;
+import ru.aritmos.events.services.EventService;
+
+class BusinessExceptionLocalizationTest {
+
+    @AfterEach
+    void tearDown() {
+        BusinessException.resetLocalization();
+    }
+
+    @Test
+    void appliesLocalizationFromConfiguration() {
+        BusinessExceptionLocalizationProperties properties = new BusinessExceptionLocalizationProperties();
+
+        properties.getHttp().setLanguage("ru");
+        properties.getHttp().setDefaultLanguage("en");
+        properties.getHttp().setMessages(
+                Map.of("Visit not found", Map.of("ru", "Визит не найден", "en", "Visit not found")));
+
+        properties.getLog().setLanguage("en");
+        properties.getLog().setDefaultLanguage("ru");
+        properties.getLog().setMessages(
+                Map.of("Визит не найден", Map.of("en", "Visit not found", "ru", "Визит не найден")));
+
+        properties.getEvent().setLanguage("kk");
+        properties.getEvent().setDefaultLanguage("ru");
+        properties.getEvent().setMessages(
+                Map.of("Визит не найден", Map.of("kk", "Қатысу табылмады", "ru", "Визит не найден")));
+
+        BusinessException.configureLocalization(new BusinessExceptionLocalization(properties));
+
+        EventService eventService = mock(EventService.class);
+
+        Logger logger = (Logger) LoggerFactory.getLogger(BusinessException.class);
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+
+        HttpStatusException thrown;
+        try {
+            thrown =
+                    assertThrows(
+                            HttpStatusException.class,
+                            () -> new BusinessException(
+                                    "Visit not found", "Визит не найден", eventService, HttpStatus.NOT_FOUND));
+        } finally {
+            logger.detachAppender(appender);
+            appender.stop();
+        }
+
+        assertEquals(HttpStatus.NOT_FOUND, thrown.getStatus());
+        assertEquals("Визит не найден", thrown.getMessage());
+        assertTrue(thrown.getBody()::isPresent);
+        assertEquals("Визит не найден", thrown.getBody().orElseThrow());
+
+        ArgumentCaptor<Event> captor = ArgumentCaptor.forClass(Event.class);
+        verify(eventService).send(eq("*"), eq(false), captor.capture());
+        Object payload = captor.getValue().getBody();
+        assertNotNull(payload);
+        BusinessException.BusinessError error = (BusinessException.BusinessError) payload;
+        assertEquals("Қатысу табылмады", error.getMessage());
+
+        assertFalse(appender.list::isEmpty);
+        assertEquals("Visit not found", appender.list.get(0).getFormattedMessage());
+    }
+}


### PR DESCRIPTION
## Summary
- добавил сервис локализации для сообщений BusinessException и статическую конфигурацию исключения
- вынес параметры языка и словари переводов в блок `business-exception.localization` и подключил конфигуратор Micronaut
- расширил тесты BusinessException проверкой настройки языков и отправляемых событий

## Testing
- mvn -s .mvn/settings.xml test

------
https://chatgpt.com/codex/tasks/task_e_68d4418bde388328b8ad0dc6d349cc14