### PR TITLE
fix: корректирую локализацию бизнес-исключений

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,8 +20,8 @@ loki:
 business-exception:
   localization:
     http:
-      language: '${BUSINESS_EXCEPTION_HTTP_LANG:`en`}'
-      default-language: en
+      language: '${BUSINESS_EXCEPTION_HTTP_LANG:`ru`}'
+      default-language: ru
     log:
       language: '${BUSINESS_EXCEPTION_LOG_LANG:`ru`}'
       default-language: ru


### PR DESCRIPTION
## Что сделано
- изменил настройки `business-exception.localization.http`, чтобы значение `BUSINESS_EXCEPTION_HTTP_LANG` и язык по умолчанию были русскими

## Зачем
- чтобы ответы бизнес-исключений через HTTP по умолчанию формировались на русском языке, как ожидает заказчик

## Проверка
- `mvn -s .mvn/settings.xml test`


------
https://chatgpt.com/codex/tasks/task_e_68d44f6f07b883289eae35bb64498aaf