### PR TITLE
fix: корректное обновление локализации BusinessException

### DIFF
--- a/src/main/java/ru/aritmos/exceptions/BusinessExceptionLocalizationConfigurer.java
+++ b/src/main/java/ru/aritmos/exceptions/BusinessExceptionLocalizationConfigurer.java
@@ -1,22 +1,35 @@
 package ru.aritmos.exceptions;
 
 import io.micronaut.context.annotation.Context;
+import io.micronaut.runtime.context.scope.refresh.RefreshEvent;
+import io.micronaut.runtime.event.annotation.EventListener;
 import jakarta.annotation.PostConstruct;
+import jakarta.inject.Singleton;
 
 /**
  * Подключение настроек локализации к {@link BusinessException}.
  */
 @Context
+@Singleton
 public class BusinessExceptionLocalizationConfigurer {
 
-  private final BusinessExceptionLocalization localization;
+  private final BusinessExceptionLocalizationProperties properties;
 
-  public BusinessExceptionLocalizationConfigurer(BusinessExceptionLocalization localization) {
-    this.localization = localization;
+  public BusinessExceptionLocalizationConfigurer(BusinessExceptionLocalizationProperties properties) {
+    this.properties = properties;
   }
 
   @PostConstruct
   void configure() {
-    BusinessException.configureLocalization(localization);
+    updateLocalization();
+  }
+
+  @EventListener
+  void refreshLocalization(RefreshEvent event) {
+    updateLocalization();
+  }
+
+  void updateLocalization() {
+    BusinessException.configureLocalization(new BusinessExceptionLocalization(properties));
   }
 }


### PR DESCRIPTION
## Summary
- обновил конфигуратор локализации BusinessException так, чтобы он пересоздавал настройки при запуске и по событиям RefreshEvent
- добавил модульный тест, проверяющий смену локализации HTTP/лога/события после изменения конфигурации

## Testing
- `mvn -s .mvn/settings.xml test`

------
https://chatgpt.com/codex/tasks/task_e_68d4cd9a9c648328be473a80074fd2fb