### PR TITLE
Настраиваю гибкое управление Maven-прокси через переменные окружения

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,5 +1,1 @@
 -Djava.net.preferIPv4Stack=true
--Dhttp.proxyHost=proxy
--Dhttp.proxyPort=8080
--Dhttps.proxyHost=proxy
--Dhttps.proxyPort=8080

--- a/.mvn/settings.xml
+++ b/.mvn/settings.xml
@@ -1,22 +1,32 @@
 <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <!--
+    Управление прокси полностью передано во внешний конфиг через переменные
+    окружения Maven/Java:
+      * MAVEN_HTTP_PROXY_ENABLED / MAVEN_HTTPS_PROXY_ENABLED — активирует прокси.
+      * MAVEN_HTTP_PROXY_HOST / MAVEN_HTTPS_PROXY_HOST — адрес прокси-сервера.
+      * MAVEN_HTTP_PROXY_PORT / MAVEN_HTTPS_PROXY_PORT — порт прокси-сервера.
+      * MAVEN_HTTP_DIRECT_HOSTS / MAVEN_HTTPS_DIRECT_HOSTS — адреса (через «|»),
+        для которых проксирование зависимостей отключается.
+    Если переменные не заданы, прокси не используется.
+  -->
   <proxies>
     <proxy>
-      <id>default-http</id>
-      <active>true</active>
+      <id>allowlisted-http</id>
+      <active>${env.MAVEN_HTTP_PROXY_ENABLED}</active>
       <protocol>http</protocol>
-      <host>proxy</host>
-      <port>8080</port>
-      <nonProxyHosts>localhost|127.0.0.1|::1</nonProxyHosts>
+      <host>${env.MAVEN_HTTP_PROXY_HOST}</host>
+      <port>${env.MAVEN_HTTP_PROXY_PORT}</port>
+      <nonProxyHosts>${env.MAVEN_HTTP_DIRECT_HOSTS}</nonProxyHosts>
     </proxy>
     <proxy>
-      <id>default-https</id>
-      <active>true</active>
+      <id>allowlisted-https</id>
+      <active>${env.MAVEN_HTTPS_PROXY_ENABLED}</active>
       <protocol>https</protocol>
-      <host>proxy</host>
-      <port>8080</port>
-      <nonProxyHosts>localhost|127.0.0.1|::1</nonProxyHosts>
+      <host>${env.MAVEN_HTTPS_PROXY_HOST}</host>
+      <port>${env.MAVEN_HTTPS_PROXY_PORT}</port>
+      <nonProxyHosts>${env.MAVEN_HTTPS_DIRECT_HOSTS}</nonProxyHosts>
     </proxy>
   </proxies>
 </settings>


### PR DESCRIPTION
## Summary
- перевёл прокси Maven на управление через переменные окружения, добавив возможность задавать адреса прямого доступа
- убрал жёстко зашитые JVM-параметры прокси из `.mvn/jvm.config`

## Testing
- mvn -v

------
https://chatgpt.com/codex/tasks/task_e_68d4d53621608328bbf569e6d380a53f