### PR TITLE
Отключение прокси Maven по умолчанию и обновление инструкций

### DIFF
--- a/.mvn/settings.xml
+++ b/.mvn/settings.xml
@@ -2,14 +2,15 @@
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
   <!--
-    В среде контейнера Maven должен использовать локальный прокси, доступный по имени
-    хоста «proxy». Активируем HTTP(S) прокси и явно прописываем адрес и порт,
-    чтобы сборка могла скачать зависимости без дополнительных переменных окружения.
+    Прокси-сервер (host «proxy», порт 8080) включается только при явной передаче
+    системного свойства visitmanager.proxyEnabled=true в командной строке Maven.
+    Это позволяет выполнять локальные сборки без проксирования и при необходимости
+    активировать его флагом `-Dvisitmanager.proxyEnabled=true`.
   -->
   <proxies>
     <proxy>
       <id>container-http</id>
-      <active>true</active>
+      <active>${sys.visitmanager.proxyEnabled:-false}</active>
       <protocol>http</protocol>
       <host>proxy</host>
       <port>8080</port>
@@ -17,7 +18,7 @@
     </proxy>
     <proxy>
       <id>container-https</id>
-      <active>true</active>
+      <active>${sys.visitmanager.proxyEnabled:-false}</active>
       <protocol>https</protocol>
       <host>proxy</host>
       <port>8080</port>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,11 +11,13 @@
 ## Сборка, тесты и запуск
 - Сборка с тестами: `mvn -s .mvn/settings.xml clean verify`.
 - Сборка без тестов: `mvn -s .mvn/settings.xml -DskipTests package`.
+- ⚠️ В среде Codex все команды Maven выполняйте с параметром `-Dvisitmanager.proxyEnabled=true`,
+  чтобы явно включить проксирование при сборке.
 - Запуск JAR: `java -jar target/visitmanager.jar`.
 - Запуск в dev (если подключен плагин): `mvn -s .mvn/settings.xml mn:run`.
 - Тесты: `mvn -s .mvn/settings.xml test`.
 
-- Сетевое окружение использует обязательный HTTP(S)-прокси `proxy:8080`; параметры уже прописаны в `.mvn/jvm.config` и `.mvn/settings.xml`. При работе вне текущей инфраструктуры обновляйте `proxy` и `port` в этих файлах или задавайте собственные значения через `JAVA_TOOL_OPTIONS`/`MAVEN_OPTS` перед запуском Maven. Значение `http.nonProxyHosts` указывайте только через `settings.xml` или переменные окружения (`MAVEN_OPTS`, `JAVA_TOOL_OPTIONS`), чтобы избежать ошибок интерпретации символа `|` в `mvnw.cmd` на Windows (сообщение вида «"127.0.0.1" не является внутренней или внешней командой...»).
+- Для доступа к зависимостям при необходимости используйте HTTP(S)-прокси `proxy:8080`. Прокси включается передачей параметра `-Dvisitmanager.proxyEnabled=true` (см. `.mvn/settings.xml`). Вне инфраструктуры, где прокси недоступен, выполняйте сборки без параметра либо указывайте свои значения через `JAVA_TOOL_OPTIONS`/`MAVEN_OPTS`. Значение `http.nonProxyHosts` задавайте только через `settings.xml` или переменные окружения (`MAVEN_OPTS`, `JAVA_TOOL_OPTIONS`), чтобы избежать ошибок интерпретации символа `|` в `mvnw.cmd` на Windows (сообщение вида «"127.0.0.1" не является внутренней или внешней командой...»).
 - Локально в Docker: `docker compose -f docker-compose.local.yml up -d --build`; остановка — `docker compose -f docker-compose.local.yml down`.
 
 ## Стиль кодирования и соглашения


### PR DESCRIPTION
## Описание
- задал значение `false` по умолчанию для свойства `visitmanager.proxyEnabled` в `.mvn/settings.xml`, чтобы прокси не активировался без явного параметра

## Тестирование
- тесты не запускались: изменения затронули только конфигурацию Maven

------
https://chatgpt.com/codex/tasks/task_e_68d4edaeff208328a7047fc83ef96eff