### PR TITLE
Fix Maven proxy configuration to restore dependency downloads

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,2 +1,2 @@
 -s=.mvn/settings.xml
--Dvisitmanager.proxyEnabled=false
+-Dvisitmanager.proxyEnabled=true

--- a/.mvn/settings.xml
+++ b/.mvn/settings.xml
@@ -8,7 +8,7 @@
   <proxies>
     <proxy>
       <id>visitmanager-http-proxy</id>
-      <active>${visitmanager.proxyEnabled}</active>
+      <active>true</active>
       <protocol>http</protocol>
       <host>proxy</host>
       <port>8080</port>
@@ -16,7 +16,7 @@
     </proxy>
     <proxy>
       <id>visitmanager-https-proxy</id>
-      <active>${visitmanager.proxyEnabled}</active>
+      <active>true</active>
       <protocol>https</protocol>
       <host>proxy</host>
       <port>8080</port>


### PR DESCRIPTION
## Summary
- включил HTTP и HTTPS прокси в `.mvn/settings.xml`, чтобы Maven всегда использовал корпоративный прокси
- скорректировал `.mvn/maven.config`, активировав свойство `visitmanager.proxyEnabled` по умолчанию

## Testing
- mvn test

------
https://chatgpt.com/codex/tasks/task_e_68d4f7ffebdc8328912444da991f0cab