### PR TITLE
Allow disabling Maven proxy via CLI property override

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,2 +1,1 @@
 -s=.mvn/settings.xml
--Dvisitmanager.proxyEnabled=false

--- a/.mvn/settings.xml
+++ b/.mvn/settings.xml
@@ -2,13 +2,14 @@
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
   <!--
-    Прокси отключён по умолчанию. Чтобы включить проксирование, запустите Maven
-    с параметром `-Dvisitmanager.proxyEnabled=true` (например, через `mvnw`).
+    Прокси включён по умолчанию за счёт значения по умолчанию в
+    `${visitmanager.proxyEnabled:-true}`. Чтобы отключить проксирование,
+    запустите Maven с параметром `-Dvisitmanager.proxyEnabled=false`.
   -->
   <proxies>
     <proxy>
       <id>visitmanager-http-proxy</id>
-      <active>${visitmanager.proxyEnabled}</active>
+      <active>${visitmanager.proxyEnabled:-true}</active>
       <protocol>http</protocol>
       <host>proxy</host>
       <port>8080</port>
@@ -16,11 +17,12 @@
     </proxy>
     <proxy>
       <id>visitmanager-https-proxy</id>
-      <active>${visitmanager.proxyEnabled}</active>
+      <active>${visitmanager.proxyEnabled:-true}</active>
       <protocol>https</protocol>
       <host>proxy</host>
       <port>8080</port>
       <nonProxyHosts>localhost|127.0.0.1</nonProxyHosts>
     </proxy>
   </proxies>
+
 </settings>


### PR DESCRIPTION
## Summary
- включил значение по умолчанию `${visitmanager.proxyEnabled:-true}` для автоматической активации http/https‑прокси
- описал в `.mvn/settings.xml`, что прокси отключается передачей `-Dvisitmanager.proxyEnabled=false`

## Testing
- mvn -s .mvn/settings.xml test
- mvn -s .mvn/settings.xml -Dvisitmanager.proxyEnabled=false test

------
https://chatgpt.com/codex/tasks/task_e_68d4f7ffebdc8328912444da991f0cab