### PR TITLE
Локализация описаний @DisplayName для тестов исключений (итерация 1)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,3 +145,6 @@
 
 ## Отслеживание описаний тестов
 - 2025-09-28: выполнена ревизия каталога `src/test`. Все методы с `@Test` снабжены аннотациями `@DisplayName`. При добавлении новых тестов обязательно указывайте человеко-читаемое описание через `@DisplayName`, чтобы поддерживать единый формат отчётности.
+
+## Прогресс локализации @DisplayName
+- 2025-09-29 (итерация 1): описания тестов в `src/test/unit/java/ru/aritmos/exceptions/BusinessExceptionTest.java` и `src/test/unit/java/ru/aritmos/exceptions/SystemExceptionTest.java` переведены на русский язык и приведены к единому стилю.

--- a/src/test/unit/java/ru/aritmos/exceptions/BusinessExceptionTest.java
+++ b/src/test/unit/java/ru/aritmos/exceptions/BusinessExceptionTest.java
@@ -15,7 +15,7 @@ import ru.aritmos.events.services.EventService;
 
 class BusinessExceptionTest {
 
-    @DisplayName("Publishes Event And Throws")
+    @DisplayName("Публикует событие и выбрасывает исключение")
     @Test
     void publishesEventAndThrows() {
         EventService eventService = mock(EventService.class);
@@ -34,7 +34,7 @@ class BusinessExceptionTest {
         assertEquals("BUSINESS_ERROR", captor.getValue().getEventType());
     }
 
-    @DisplayName("Publishes Event With Log Message")
+    @DisplayName("Публикует событие и пишет сообщение в лог")
     @Test
     void publishesEventWithLogMessage() {
         EventService eventService = mock(EventService.class);
@@ -53,7 +53,7 @@ class BusinessExceptionTest {
         assertEquals("BUSINESS_ERROR", captor.getValue().getEventType());
     }
 
-    @DisplayName("Publishes Event With Mapper")
+    @DisplayName("Публикует событие с использованием маппера")
     @Test
     void publishesEventWithMapper() throws Exception {
         EventService eventService = mock(EventService.class);
@@ -74,7 +74,7 @@ class BusinessExceptionTest {
         verify(mapper, atLeastOnce()).writeValueAsString(any());
     }
 
-    @DisplayName("Publishes Event With Object Body")
+    @DisplayName("Публикует событие с объектом в теле")
     @Test
     void publishesEventWithObjectBody() {
         EventService eventService = mock(EventService.class);
@@ -93,7 +93,7 @@ class BusinessExceptionTest {
         assertEquals("BUSINESS_ERROR", captor.getValue().getEventType());
     }
 
-    @DisplayName("Publishes Event With Separate Event Message")
+    @DisplayName("Публикует событие с отдельным сообщением события")
     @Test
     void publishesEventWithSeparateEventMessage() {
         EventService eventService = mock(EventService.class);

--- a/src/test/unit/java/ru/aritmos/exceptions/SystemExceptionTest.java
+++ b/src/test/unit/java/ru/aritmos/exceptions/SystemExceptionTest.java
@@ -14,7 +14,7 @@ import ru.aritmos.events.services.EventService;
 
 class SystemExceptionTest {
 
-    @DisplayName("Sends System Error Event On Creation")
+    @DisplayName("Отправляет событие системной ошибки при создании")
     @Test
     void sendsSystemErrorEventOnCreation() {
         EventService eventService = Mockito.mock(EventService.class);


### PR DESCRIPTION
## Что сделано
- локализованы и унифицированы описания `@DisplayName` в `BusinessExceptionTest` и `SystemExceptionTest`
- зафиксирован прогресс первой итерации локализации в `AGENTS.md`

## Зачем
- чтобы обеспечить единый стиль русскоязычных описаний тестов и подготовить почву для последующих итераций

## План проверки
- убедиться, что `mvn -s .mvn/settings.xml test` выполняется успешно (изменения не затрагивают код)

## Конфигурация
- изменений нет

## Риски
- минимальные: правки затрагивают только человекочитаемые описания тестов

------
https://chatgpt.com/codex/tasks/task_e_68d52cc415fc832890a1026c99947961