### PR TITLE
Локализация описаний @DisplayName для тестов VisitService (итерация 3)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,3 +145,8 @@
 
 ## Отслеживание описаний тестов
 - 2025-09-28: выполнена ревизия каталога `src/test`. Все методы с `@Test` снабжены аннотациями `@DisplayName`. При добавлении новых тестов обязательно указывайте человеко-читаемое описание через `@DisplayName`, чтобы поддерживать единый формат отчётности.
+
+## Прогресс локализации @DisplayName
+- 2025-09-29 (итерация 1): описания тестов в `src/test/unit/java/ru/aritmos/exceptions/BusinessExceptionTest.java` и `src/test/unit/java/ru/aritmos/exceptions/SystemExceptionTest.java` переведены на русский язык и приведены к единому стилю.
+- 2025-09-29 (итерация 2): локализованы описания тестов в `src/test/unit/java/ru/aritmos/exceptions/BusinessExceptionLocalizationPropertiesTest.java` и `src/test/unit/java/ru/aritmos/exceptions/BusinessExceptionLocalizationTest.java`.
+- 2025-09-29 (итерация 3): переведены и унифицированы описания тестов в `src/test/unit/java/ru/aritmos/service/VisitServiceVisitAutoCallTest.java`, `src/test/unit/java/ru/aritmos/service/VisitServiceAddServiceTest.java` и `src/test/unit/java/ru/aritmos/service/VisitServiceVisitCallTest.java`.

--- a/src/test/unit/java/ru/aritmos/exceptions/BusinessExceptionLocalizationPropertiesTest.java
+++ b/src/test/unit/java/ru/aritmos/exceptions/BusinessExceptionLocalizationPropertiesTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 
 class BusinessExceptionLocalizationPropertiesTest {
 
-    @DisplayName("Language Is Normalized By Removing Wrapping Quotes")
+    @DisplayName("Нормализует язык, убирая внешние кавычки")
     @Test
     void languageIsNormalizedByRemovingWrappingQuotes() {
         BusinessExceptionLocalizationProperties.ChannelLocalization localization =
@@ -21,7 +21,7 @@ class BusinessExceptionLocalizationPropertiesTest {
         assertEquals("en", localization.getDefaultLanguage());
     }
 
-    @DisplayName("Placeholder With Default Value Returns It")
+    @DisplayName("Возвращает язык из плейсхолдера со значением по умолчанию")
     @Test
     void placeholderWithDefaultValueReturnsIt() {
         BusinessExceptionLocalizationProperties.ChannelLocalization localization =
@@ -32,7 +32,7 @@ class BusinessExceptionLocalizationPropertiesTest {
         assertEquals("ru", localization.getLanguage());
     }
 
-    @DisplayName("Placeholder Without Default Value Clears Language")
+    @DisplayName("Очищает язык, если плейсхолдер без значения по умолчанию")
     @Test
     void placeholderWithoutDefaultValueClearsLanguage() {
         BusinessExceptionLocalizationProperties.ChannelLocalization localization =
@@ -43,7 +43,7 @@ class BusinessExceptionLocalizationPropertiesTest {
         assertNull(localization.getLanguage());
     }
 
-    @DisplayName("Log Fallback Enabled When Languages Match After Normalization")
+    @DisplayName("Включает резерв журналирования, когда языки совпадают после нормализации")
     @Test
     void logFallbackEnabledWhenLanguagesMatchAfterNormalization() {
         BusinessExceptionLocalizationProperties.ChannelLocalization http =
@@ -73,7 +73,7 @@ class BusinessExceptionLocalizationPropertiesTest {
     }
 
 
-    @DisplayName("Resource Localization Provides Russian Translation")
+    @DisplayName("Возвращает русский перевод из ресурсной локализации")
     @Test
     void resourceLocalizationProvidesRussianTranslation() {
         BusinessExceptionLocalizationProperties.ChannelLocalization http =
@@ -96,7 +96,7 @@ class BusinessExceptionLocalizationPropertiesTest {
         assertEquals("Отделение не найдено", messages.responseBody());
     }
 
-    @DisplayName("Resource Localization Returns English Translation For Russian Key")
+    @DisplayName("Возвращает английский перевод для ключа русской локализации")
     @Test
     void resourceLocalizationReturnsEnglishTranslationForRussianKey() {
         BusinessExceptionLocalizationProperties.ChannelLocalization http =
@@ -119,7 +119,7 @@ class BusinessExceptionLocalizationPropertiesTest {
         assertEquals("Delayed return has not yet been completed", messages.responseBody());
     }
 
-    @DisplayName("Configurer Reconfigures Localization After Update")
+    @DisplayName("Переинициализирует локализацию после обновления настроек")
     @Test
     void configurerReconfiguresLocalizationAfterUpdate() {
         BusinessException.resetLocalization();

--- a/src/test/unit/java/ru/aritmos/exceptions/BusinessExceptionLocalizationTest.java
+++ b/src/test/unit/java/ru/aritmos/exceptions/BusinessExceptionLocalizationTest.java
@@ -26,7 +26,7 @@ class BusinessExceptionLocalizationTest {
         BusinessException.resetLocalization();
     }
 
-    @DisplayName("Applies Localization From Configuration")
+    @DisplayName("Применяет локализацию из настроек")
     @Test
     void appliesLocalizationFromConfiguration() {
         BusinessExceptionLocalizationProperties properties = new BusinessExceptionLocalizationProperties();
@@ -83,7 +83,7 @@ class BusinessExceptionLocalizationTest {
         assertEquals("Visit not found", appender.list.get(0).getFormattedMessage());
     }
 
-    @DisplayName("Replaces Message Field In Map Response Body")
+    @DisplayName("Заменяет поле «message» в теле ответа типа Map")
     @Test
     void replacesMessageFieldInMapResponseBody() {
         BusinessExceptionLocalizationProperties properties = new BusinessExceptionLocalizationProperties();

--- a/src/test/unit/java/ru/aritmos/exceptions/BusinessExceptionTest.java
+++ b/src/test/unit/java/ru/aritmos/exceptions/BusinessExceptionTest.java
@@ -15,7 +15,7 @@ import ru.aritmos.events.services.EventService;
 
 class BusinessExceptionTest {
 
-    @DisplayName("Publishes Event And Throws")
+    @DisplayName("Публикует событие и выбрасывает исключение")
     @Test
     void publishesEventAndThrows() {
         EventService eventService = mock(EventService.class);
@@ -34,7 +34,7 @@ class BusinessExceptionTest {
         assertEquals("BUSINESS_ERROR", captor.getValue().getEventType());
     }
 
-    @DisplayName("Publishes Event With Log Message")
+    @DisplayName("Публикует событие и пишет сообщение в лог")
     @Test
     void publishesEventWithLogMessage() {
         EventService eventService = mock(EventService.class);
@@ -53,7 +53,7 @@ class BusinessExceptionTest {
         assertEquals("BUSINESS_ERROR", captor.getValue().getEventType());
     }
 
-    @DisplayName("Publishes Event With Mapper")
+    @DisplayName("Публикует событие с использованием маппера")
     @Test
     void publishesEventWithMapper() throws Exception {
         EventService eventService = mock(EventService.class);
@@ -74,7 +74,7 @@ class BusinessExceptionTest {
         verify(mapper, atLeastOnce()).writeValueAsString(any());
     }
 
-    @DisplayName("Publishes Event With Object Body")
+    @DisplayName("Публикует событие с объектом в теле")
     @Test
     void publishesEventWithObjectBody() {
         EventService eventService = mock(EventService.class);
@@ -93,7 +93,7 @@ class BusinessExceptionTest {
         assertEquals("BUSINESS_ERROR", captor.getValue().getEventType());
     }
 
-    @DisplayName("Publishes Event With Separate Event Message")
+    @DisplayName("Публикует событие с отдельным сообщением события")
     @Test
     void publishesEventWithSeparateEventMessage() {
         EventService eventService = mock(EventService.class);

--- a/src/test/unit/java/ru/aritmos/exceptions/SystemExceptionTest.java
+++ b/src/test/unit/java/ru/aritmos/exceptions/SystemExceptionTest.java
@@ -14,7 +14,7 @@ import ru.aritmos.events.services.EventService;
 
 class SystemExceptionTest {
 
-    @DisplayName("Sends System Error Event On Creation")
+    @DisplayName("Отправляет событие системной ошибки при создании")
     @Test
     void sendsSystemErrorEventOnCreation() {
         EventService eventService = Mockito.mock(EventService.class);

--- a/src/test/unit/java/ru/aritmos/service/VisitServiceAddServiceTest.java
+++ b/src/test/unit/java/ru/aritmos/service/VisitServiceAddServiceTest.java
@@ -19,7 +19,7 @@ import ru.aritmos.model.visit.VisitEvent;
  */
 class VisitServiceAddServiceTest {
 
-    @DisplayName("Adds Service To Unserved Services")
+    @DisplayName("Добавляет услугу в список необслуженных")
     @Test
     void addsServiceToUnservedServices() {
         Branch branch = new Branch("b1", "Branch");
@@ -44,7 +44,7 @@ class VisitServiceAddServiceTest {
         verify(branchService).updateVisit(eq(visit), any(VisitEvent.class), eq(service));
     }
 
-    @DisplayName("Throws When Service Missing")
+    @DisplayName("Выбрасывает исключение, если услуга не найдена")
     @Test
     void throwsWhenServiceMissing() {
         Branch branch = new Branch("b1", "Branch");

--- a/src/test/unit/java/ru/aritmos/service/VisitServiceVisitAutoCallTest.java
+++ b/src/test/unit/java/ru/aritmos/service/VisitServiceVisitAutoCallTest.java
@@ -17,7 +17,7 @@ import ru.aritmos.service.rules.CallRule;
  */
 class VisitServiceVisitAutoCallTest {
 
-    @DisplayName("Auto Call Disables Mode After Successful Call")
+    @DisplayName("Автовызов отключает режим после успешного дозвона")
     @Test
     void autoCallDisablesModeAfterSuccessfulCall() {
         Branch branch = new Branch("b1", "Branch");
@@ -51,7 +51,7 @@ class VisitServiceVisitAutoCallTest {
         verify(service, never()).visitCallForConfirmWithMaxWaitingTime(anyString(), anyString(), any(Visit.class));
     }
 
-    @DisplayName("Auto Call Uses Confirm Flow When Required")
+    @DisplayName("Автовызов использует сценарий подтверждения, когда это требуется")
     @Test
     void autoCallUsesConfirmFlowWhenRequired() {
         Branch branch = new Branch("b1", "Branch");
@@ -88,7 +88,7 @@ class VisitServiceVisitAutoCallTest {
         verify(service).visitCallForConfirmWithMaxWaitingTime(eq("b1"), eq("sp1"), same(visit));
     }
 
-    @DisplayName("Auto Call Returns Original When Mode Disabled")
+    @DisplayName("Автовызов возвращает исходный визит, когда режим отключён")
     @Test
     void autoCallReturnsOriginalWhenModeDisabled() {
         Branch branch = new Branch("b1", "Branch");
@@ -113,7 +113,7 @@ class VisitServiceVisitAutoCallTest {
         verifyNoInteractions(waitingRule);
     }
 
-    @DisplayName("Auto Call Returns Original When No Service Point Found")
+    @DisplayName("Автовызов возвращает исходный визит, когда окно не найдено")
     @Test
     void autoCallReturnsOriginalWhenNoServicePointFound() {
         Branch branch = new Branch("b1", "Branch");
@@ -141,7 +141,7 @@ class VisitServiceVisitAutoCallTest {
         verify(waitingRule).getAvailiableServicePoints(same(branch), same(visit));
     }
 
-    @DisplayName("Auto Call Keeps Mode When Call Returns Empty")
+    @DisplayName("Автовызов сохраняет режим, если вызов не возвращает визит")
     @Test
     void autoCallKeepsModeWhenCallReturnsEmpty() {
         Branch branch = new Branch("b1", "Branch");

--- a/src/test/unit/java/ru/aritmos/service/VisitServiceVisitCallTest.java
+++ b/src/test/unit/java/ru/aritmos/service/VisitServiceVisitCallTest.java
@@ -46,7 +46,7 @@ class VisitServiceVisitCallTest {
         VisitEvent.START_SERVING.getParameters().clear();
     }
 
-    @DisplayName("Visit Call Moves Visit From Queue And Publishes Events")
+    @DisplayName("Вызов визита переносит клиента из очереди и публикует события")
     @Test
     void visitCallMovesVisitFromQueueAndPublishesEvents() {
         Branch branch = new Branch("b1", "Отделение");
@@ -108,7 +108,7 @@ class VisitServiceVisitCallTest {
         assertSame(VisitEvent.START_SERVING, startServingEvent);
     }
 
-    @DisplayName("Visit Call Fails When Service Point Busy")
+    @DisplayName("Вызов визита завершается ошибкой, если окно занято")
     @Test
     void visitCallFailsWhenServicePointBusy() {
         Branch branch = new Branch("b1", "Отделение");
@@ -133,7 +133,7 @@ class VisitServiceVisitCallTest {
         verify(branchService, never()).updateVisit(any(Visit.class), any(VisitEvent.class), same(service));
     }
 
-    @DisplayName("Visit Call Fails When Service Point Missing")
+    @DisplayName("Вызов визита завершается ошибкой, если окно не найдено")
     @Test
     void visitCallFailsWhenServicePointMissing() {
         Branch branch = new Branch("b1", "Отделение");
@@ -154,7 +154,7 @@ class VisitServiceVisitCallTest {
         verify(branchService, never()).updateVisit(any(Visit.class), any(VisitEvent.class), same(service));
     }
 
-    @DisplayName("Visit Call Transfers Pool Metadata To Parameters")
+    @DisplayName("Вызов визита переносит данные пула в параметры визита")
     @Test
     void visitCallTransfersPoolMetadataToParameters() {
         Branch branch = new Branch("b1", "Отделение");
@@ -185,7 +185,7 @@ class VisitServiceVisitCallTest {
         assertNull(visit.getPoolUserId());
     }
 
-    @DisplayName("Visit Call By Id Delegates To Cherry Pick And Handles Missing")
+    @DisplayName("Вызов визита по идентификатору делегирует обработчику «cherry-pick» и корректно реагирует на отсутствие визита")
     @Test
     void visitCallByIdDelegatesToCherryPickAndHandlesMissing() {
         Visit visit = Visit.builder().id("v1").branchId("b1").parameterMap(new HashMap<>()).build();


### PR DESCRIPTION
## Что сделано
- перевёл на русский язык и унифицировал описания `@DisplayName` в тестах `VisitServiceVisitAutoCallTest`, `VisitServiceAddServiceTest` и `VisitServiceVisitCallTest`
- зафиксировал третью итерацию работ по локализации в `AGENTS.md`

## Зачем
- чтобы продолжить планомерную локализацию подписей тестов и придерживаться единого русского стиля формулировок

## План проверки
- выполнить `mvn -s .mvn/settings.xml test`

## Конфигурация
- изменений нет

## Риски
- минимальные: изменены только человекочитаемые описания тестов


------
https://chatgpt.com/codex/tasks/task_e_68d52cc415fc832890a1026c99947961