### PR TITLE
fix: локализовать описания тридцати тестов

### DIFF
--- a/src/test/unit/java/ru/aritmos/model/RealmAccessTest.java
+++ b/src/test/unit/java/ru/aritmos/model/RealmAccessTest.java
@@ -10,7 +10,7 @@ import org.keycloak.representations.idm.GroupRepresentation;
 
 class RealmAccessTest {
 
-    @DisplayName("Builder And Setters Construct Full Access")
+    @DisplayName("Строитель и сеттеры формируют полный доступ")
     @Test
     void builderAndSettersConstructFullAccess() {
         GroupRepresentation branch = new GroupRepresentation();

--- a/src/test/unit/java/ru/aritmos/model/ServiceGroupTest.java
+++ b/src/test/unit/java/ru/aritmos/model/ServiceGroupTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 
 class ServiceGroupTest {
 
-    @DisplayName("Custom Constructor Should Fill Hierarchy Fields")
+    @DisplayName("Пользовательский конструктор заполняет поля иерархии")
     @Test
     void customConstructorShouldFillHierarchyFields() {
         List<String> services = List.of("s1", "s2");
@@ -21,7 +21,7 @@ class ServiceGroupTest {
         assertEquals(services, group.getServiceIds());
     }
 
-    @DisplayName("Segmentation Identifiers Should Be Mutable")
+    @DisplayName("Идентификаторы сегментации допускают изменение")
     @Test
     void segmentationIdentifiersShouldBeMutable() {
         ServiceGroup group = new ServiceGroup();

--- a/src/test/unit/java/ru/aritmos/model/ServiceTest.java
+++ b/src/test/unit/java/ru/aritmos/model/ServiceTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 
 class ServiceTest {
 
-    @DisplayName("Clone Should Copy Fields And Maps Independently")
+    @DisplayName("Метод clone копирует поля и карты независимо")
     @Test
     void cloneShouldCopyFieldsAndMapsIndependently() {
         Outcome outcome = new Outcome("1", "outcome");

--- a/src/test/unit/java/ru/aritmos/model/TokenTest.java
+++ b/src/test/unit/java/ru/aritmos/model/TokenTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 
 class TokenTest {
 
-    @DisplayName("Builder And Setters Transfer Token Data")
+    @DisplayName("Строитель и сеттеры переносят данные токена")
     @Test
     void builderAndSettersTransferTokenData() {
         Token viaBuilder = Token.builder()

--- a/src/test/unit/java/ru/aritmos/model/UserSessionTest.java
+++ b/src/test/unit/java/ru/aritmos/model/UserSessionTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 
 class UserSessionTest {
 
-    @DisplayName("Builder Should Provide Empty Params By Default")
+    @DisplayName("Строитель по умолчанию создаёт пустые параметры")
     @Test
     void builderShouldProvideEmptyParamsByDefault() {
         UserSession session = UserSession.builder().login("ivan").build();
@@ -18,7 +18,7 @@ class UserSessionTest {
         assertTrue(session.getParams().isEmpty());
     }
 
-    @DisplayName("Setters Should Update Mutable Fields")
+    @DisplayName("Сеттеры обновляют изменяемые поля")
     @Test
     void settersShouldUpdateMutableFields() {
         UserSession session = new UserSession();

--- a/src/test/unit/java/ru/aritmos/model/keycloak/ClientAccessTest.java
+++ b/src/test/unit/java/ru/aritmos/model/keycloak/ClientAccessTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 
 class ClientAccessTest {
 
-    @DisplayName("Builder And Setters Produce Same Result")
+    @DisplayName("Строитель и сеттеры дают одинаковый результат")
     @Test
     void builderAndSettersProduceSameResult() {
         ClientAccess viaBuilder = ClientAccess.builder()

--- a/src/test/unit/java/ru/aritmos/model/visit/VisitEventInformationTest.java
+++ b/src/test/unit/java/ru/aritmos/model/visit/VisitEventInformationTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 
 class VisitEventInformationTest {
 
-    @DisplayName("Builder Should Create Instance With All Fields")
+    @DisplayName("Строитель формирует экземпляр со всеми полями")
     @Test
     void builderShouldCreateInstanceWithAllFields() {
         ZonedDateTime now = ZonedDateTime.now();

--- a/src/test/unit/java/ru/aritmos/model/visit/VisitEventTest.java
+++ b/src/test/unit/java/ru/aritmos/model/visit/VisitEventTest.java
@@ -7,34 +7,34 @@ import org.junit.jupiter.api.Test;
 
 class VisitEventTest {
 
-    @DisplayName("Test Is New Of Transaction")
+    @DisplayName("Событие помечается как новое в рамках транзакции")
     @Test
     void testIsNewOfTransaction() {
         assertTrue(VisitEvent.isNewOfTransaction(VisitEvent.STOP_SERVING));
         assertFalse(VisitEvent.isNewOfTransaction(VisitEvent.CREATED));
     }
 
-    @DisplayName("Test Is Front End Event")
+    @DisplayName("Событие распознаётся как фронтовое")
     @Test
     void testIsFrontEndEvent() {
         assertTrue(VisitEvent.isFrontEndEvent(VisitEvent.CREATED));
         assertFalse(VisitEvent.isFrontEndEvent(VisitEvent.VISIT_END_TRANSACTION));
     }
 
-    @DisplayName("Test Is Ignored In Stat")
+    @DisplayName("Событие учитывает признак игнорирования в статистике")
     @Test
     void testIsIgnoredInStat() {
         assertFalse(VisitEvent.isIgnoredInStat(VisitEvent.CREATED));
     }
 
-    @DisplayName("Test Get Status")
+    @DisplayName("Метод getStatus возвращает корректный статус события")
     @Test
     void testGetStatus() {
         assertEquals(TransactionCompletionStatus.STOP_SERVING, VisitEvent.getStatus(VisitEvent.STOP_SERVING));
         assertNull(VisitEvent.getStatus(VisitEvent.CREATED));
     }
 
-    @DisplayName("Test Can Be Next")
+    @DisplayName("Метод canBeNext определяет допустимость следующего события")
     @Test
     void testCanBeNext() {
         VisitEvent current = VisitEvent.CREATED;
@@ -47,7 +47,7 @@ class VisitEventTest {
         assertFalse(current.canBeNext(nextForbidden));
     }
 
-    @DisplayName("Test Get State")
+    @DisplayName("Метод getState возвращает состояние события")
     @Test
     void testGetState() {
         assertEquals(VisitState.CREATED, VisitEvent.CREATED.getState());

--- a/src/test/unit/java/ru/aritmos/model/visit/VisitTest.java
+++ b/src/test/unit/java/ru/aritmos/model/visit/VisitTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 
 class VisitTest {
 
-    @DisplayName("Get Waiting Time Calculates Difference")
+    @DisplayName("Метод getWaitingTime рассчитывает продолжительность ожидания")
     @Test
     void getWaitingTimeCalculatesDifference() {
         ZonedDateTime start = ZonedDateTime.now();
@@ -22,7 +22,7 @@ class VisitTest {
         assertEquals(10L, visit.getWaitingTime());
     }
 
-    @DisplayName("Get Returning Time Uses Return Date Time")
+    @DisplayName("Метод getReturningTime использует время возврата")
     @Test
     void getReturningTimeUsesReturnDateTime() {
         ZonedDateTime returnTime = ZonedDateTime.now().minusSeconds(5);
@@ -32,14 +32,14 @@ class VisitTest {
         assertTrue(Math.abs(actual - expected) <= 1);
     }
 
-    @DisplayName("Get Returning Time Returns Zero When Null")
+    @DisplayName("Метод getReturningTime возвращает ноль при отсутствии времени возврата")
     @Test
     void getReturningTimeReturnsZeroWhenNull() {
         Visit visit = Visit.builder().build();
         assertEquals(0L, visit.getReturningTime());
     }
 
-    @DisplayName("Get Transfering Time Uses Transfer Date Time")
+    @DisplayName("Метод getTransferingTime использует время перевода")
     @Test
     void getTransferingTimeUsesTransferDateTime() {
         ZonedDateTime transferTime = ZonedDateTime.now().minusSeconds(7);
@@ -49,7 +49,7 @@ class VisitTest {
         assertTrue(Math.abs(actual - expected) <= 1);
     }
 
-    @DisplayName("Get Visit Life Time Calculates Difference")
+    @DisplayName("Метод getVisitLifeTime рассчитывает длительность визита")
     @Test
     void getVisitLifeTimeCalculatesDifference() {
         ZonedDateTime start = ZonedDateTime.now();
@@ -61,7 +61,7 @@ class VisitTest {
         assertEquals(20L, visit.getVisitLifeTime());
     }
 
-    @DisplayName("Get Serving Time Calculates Difference")
+    @DisplayName("Метод getServingTime рассчитывает время обслуживания")
     @Test
     void getServingTimeCalculatesDifference() {
         ZonedDateTime start = ZonedDateTime.now();

--- a/src/test/unit/java/ru/aritmos/service/rules/SegmentationRuleTest.java
+++ b/src/test/unit/java/ru/aritmos/service/rules/SegmentationRuleTest.java
@@ -47,7 +47,7 @@ class SegmentationRuleTest {
     }
 
     /** Проверяем выбор очереди при совпадении правил сегментации. */
-    @DisplayName("Returns Queue When Rule Matches")
+    @DisplayName("Правило возвращает очередь при совпадении условий")
     @Test
     void returnsQueueWhenRuleMatches() throws SystemException {
         LOG.info("Шаг 1: создаём отделение с очередью и данными сегментации");
@@ -81,7 +81,7 @@ class SegmentationRuleTest {
     }
 
     /** Проверяем обработку отсутствующего правила сегментации. */
-    @DisplayName("Throws When Segmentation Rule Missing")
+    @DisplayName("При отсутствии правила сегментации выбрасывается исключение")
     @Test
     void throwsWhenSegmentationRuleMissing() {
         LOG.info("Шаг 1: настраиваем мок сервиса отделений и визит");
@@ -96,7 +96,7 @@ class SegmentationRuleTest {
     }
 
     /** Проверяем возврат привязанной очереди, если правило не определено. */
-    @DisplayName("Returns Linked Queue When No Rules")
+    @DisplayName("При отсутствии правил используется связанная очередь")
     @Test
     void returnsLinkedQueueWhenNoRules() throws SystemException {
         LOG.info("Шаг 1: формируем отделение с единственной очередью");
@@ -114,7 +114,7 @@ class SegmentationRuleTest {
     }
 
     /** Проверяем выполнение groovy-правила. */
-    @DisplayName("Get Queue By Id Executes Groovy Rule")
+    @DisplayName("Метод getQueueById выполняет groovy-правило")
     @Test
     void getQueueByIdExecutesGroovyRule() {
         LOG.info("Шаг 1: настраиваем groovy-скрипт для возврата очереди");
@@ -150,7 +150,7 @@ class SegmentationRuleTest {
     }
 
     /** Проверяем пустой идентификатор groovy-правила. */
-    @DisplayName("Get Queue By Id Returns Empty When Id Null Or Empty")
+    @DisplayName("Метод getQueueById возвращает пустой результат без идентификатора")
     @Test
     void getQueueByIdReturnsEmptyWhenIdNullOrEmpty() {
         LOG.info("Шаг 1: подготавливаем визит без идентификатора правила");
@@ -166,7 +166,7 @@ class SegmentationRuleTest {
     }
 
     /** Проверяем выброс ошибки при отсутствии входных параметров для groovy. */
-    @DisplayName("Get Queue By Id Throws When Input Params Missing")
+    @DisplayName("Метод getQueueById выбрасывает исключение при отсутствии параметров")
     @Test
     void getQueueByIdThrowsWhenInputParamsMissing() {
         LOG.info("Шаг 1: формируем groovy-правило без необходимых параметров");
@@ -194,7 +194,7 @@ class SegmentationRuleTest {
     }
 
     /** Проверяем, что ошибки внутренних вызовов оборачиваются в {@link SystemException}. */
-    @DisplayName("Get Queue Wraps Business Exception Into System Exception")
+    @DisplayName("Метод getQueue оборачивает бизнес-исключение в системное")
     @Test
     void getQueueWrapsBusinessExceptionIntoSystemException() {
         LOG.info("Шаг 1: готовим отделение с сервисной группой и отсутствующим правилом");
@@ -214,7 +214,7 @@ class SegmentationRuleTest {
     }
 
     /** Проверяем возврат пустого результата, когда очередь не найдена. */
-    @DisplayName("Returns Empty When Linked Queue Missing")
+    @DisplayName("Метод возвращает пустой результат при отсутствии связанной очереди")
     @Test
     void returnsEmptyWhenLinkedQueueMissing() throws SystemException {
         LOG.info("Шаг 1: формируем сервисную группу без связанной очереди");

--- a/src/test/unit/java/ru/aritmos/service/rules/client/CallRuleClientTest.java
+++ b/src/test/unit/java/ru/aritmos/service/rules/client/CallRuleClientTest.java
@@ -23,7 +23,7 @@ class CallRuleClientTest {
     /**
      * Клиент отправляет запрос и получает визит.
      */
-    @DisplayName("Call Rule Returns Visit")
+    @DisplayName("Клиент правила вызова возвращает визит")
     @Test
     void callRuleReturnsVisit() {
         Map<String, Object> config = Map.of(


### PR DESCRIPTION
## Summary
- локализованы 30 описаний тестов для моделей визитов и событий
- приведены к русскому стилю DisplayName в тестах сервисных правил и клиентов Keycloak

## Testing
- not run (не требовалось)


------
https://chatgpt.com/codex/tasks/task_e_68d62ba5ebfc8328b5b556687f8d57f4