### PR TITLE
fix: привести описания тестов к единому русскому стилю

### DIFF
--- a/src/test/integration/java/ru/aritmos/ExternalServicesIT.java
+++ b/src/test/integration/java/ru/aritmos/ExternalServicesIT.java
@@ -15,7 +15,7 @@ class ExternalServicesIT {
     @Inject DataBusClient dataBusClient;
     @Inject KeyCloackClient keyCloackClient;
 
-    @DisplayName("Клиент Data Bus доступен в интеграционном контексте")
+    @DisplayName("Клиент шины данных доступен в интеграционном контексте")
     @Test
     void dataBusClientAvailable() {
         assertNotNull(dataBusClient);

--- a/src/test/unit/java/ru/aritmos/ApplicationConfigurerTest.java
+++ b/src/test/unit/java/ru/aritmos/ApplicationConfigurerTest.java
@@ -52,7 +52,7 @@ class ApplicationConfigurerTest {
         verifyNoMoreInteractions(builder);
     }
 
-    @DisplayName("Включает профиль infra по умолчанию при наличии удалённых сервисов")
+    @DisplayName("Включает профиль `infra` по умолчанию при наличии удалённых сервисов")
     @Test
     void enablesInfraByDefaultWhenRemoteEndpointsAvailable() {
         System.setProperty("redis.uri", "redis://example");
@@ -66,7 +66,7 @@ class ApplicationConfigurerTest {
         verifyNoMoreInteractions(builder);
     }
 
-    @DisplayName("Добавляет профиль infra к явно указанным окружениям")
+    @DisplayName("Добавляет профиль `infra` к явно указанным окружениям")
     @Test
     void appendsInfraWhenExplicitEnvironmentsProvided() {
         System.setProperty("micronaut.environments", "dev");

--- a/src/test/unit/java/ru/aritmos/ApplicationTest.java
+++ b/src/test/unit/java/ru/aritmos/ApplicationTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
 class ApplicationTest {
-    @DisplayName("Метод main передаёт аргументы в Micronaut.run")
+    @DisplayName("Метод `main` передаёт аргументы в запуск Micronaut")
     @Test
     void main() {
         try (MockedStatic<Micronaut> mic = mockStatic(Micronaut.class)) {

--- a/src/test/unit/java/ru/aritmos/EntrypointTest.java
+++ b/src/test/unit/java/ru/aritmos/EntrypointTest.java
@@ -28,7 +28,7 @@ class EntrypointTest {
         }
     }
 
-    @DisplayName("Скрипт Groovy выбирает визит по заданным параметрам")
+    @DisplayName("Groovy-скрипт выбирает визит по заданным параметрам")
     @Test
     void groovyScriptSelectsVisitByParams() throws Exception {
         Binding binding = new Binding();
@@ -67,7 +67,7 @@ class EntrypointTest {
         assertEquals("v1", visit.get().getId());
     }
 
-    @DisplayName("Скрипт Groovy возвращает пустой результат при отсутствии совпадений")
+    @DisplayName("Groovy-скрипт возвращает пустой результат при отсутствии совпадений")
     @Test
     void groovyScriptReturnsEmptyWhenNoMatch() throws Exception {
         Binding binding = new Binding();

--- a/src/test/unit/java/ru/aritmos/api/ConfigurationControllerTest.java
+++ b/src/test/unit/java/ru/aritmos/api/ConfigurationControllerTest.java
@@ -20,7 +20,7 @@ import ru.aritmos.service.VisitService;
 
 class ConfigurationControllerTest {
 
-    @DisplayName("update делегирует создание конфигурации сервису Configuration")
+    @DisplayName("Обновление конфигурации передает работу сервису конфигурации")
     @Test
     void updateDelegatesToConfiguration() {
         ConfigurationController controller = new ConfigurationController();
@@ -36,7 +36,7 @@ class ConfigurationControllerTest {
         verify(config).createBranchConfiguration(branches);
     }
 
-    @DisplayName("update без параметров использует демо-конфигурацию")
+    @DisplayName("Обновление без параметров использует демо-конфигурацию")
     @Test
     void updateHardcodeUsesDemoConfig() {
         ConfigurationController controller = new ConfigurationController();
@@ -62,7 +62,7 @@ class ConfigurationControllerTest {
         return controller;
     }
 
-    @DisplayName("addUpdateService делегирует операцию BranchService")
+    @DisplayName("Добавление или обновление услуги выполняет сервис отделений")
     @Test
     void addUpdateServiceDelegatesToBranchService() {
         ConfigurationController controller = controller();
@@ -72,7 +72,7 @@ class ConfigurationControllerTest {
             .addUpdateService("b1", services, true, controller.visitService);
     }
 
-    @DisplayName("getBreakReasons запрашивает данные у BranchService")
+    @DisplayName("Запрос причин перерыва обращается к сервису отделений")
     @Test
     void getBreakReasonsUsesBranchService() {
         ConfigurationController controller = controller();
@@ -84,7 +84,7 @@ class ConfigurationControllerTest {
         verify(controller.branchService).getBranch("b1");
     }
 
-    @DisplayName("deleteServices делегирует удаление BranchService")
+    @DisplayName("Удаление услуг выполняет сервис отделений")
     @Test
     void deleteServicesDelegates() {
         ConfigurationController controller = controller();
@@ -94,7 +94,7 @@ class ConfigurationControllerTest {
             .deleteServices("b1", ids, false, controller.visitService);
     }
 
-    @DisplayName("addUpdateServicePoint делегирует обновление BranchService")
+    @DisplayName("Добавление или обновление точки обслуживания выполняет сервис отделений")
     @Test
     void addUpdateServicePointDelegates() {
         ConfigurationController controller = controller();
@@ -104,7 +104,7 @@ class ConfigurationControllerTest {
             .addUpdateServicePoint("b1", points, true, false);
     }
 
-    @DisplayName("addUpdateServiceGroups делегирует BranchService")
+    @DisplayName("Добавление или обновление групп услуг выполняет сервис отделений")
     @Test
     void addUpdateServiceGroupsDelegates() {
         ConfigurationController controller = controller();
@@ -113,7 +113,7 @@ class ConfigurationControllerTest {
         verify(controller.branchService).addUpdateServiceGroups("b1", groups);
     }
 
-    @DisplayName("addUpdateSegmentationRules делегирует BranchService")
+    @DisplayName("Добавление или обновление правил сегментации выполняет сервис отделений")
     @Test
     void addUpdateSegmentationRulesDelegates() {
         ConfigurationController controller = controller();
@@ -122,7 +122,7 @@ class ConfigurationControllerTest {
         verify(controller.branchService).addUpdateSegmentationRules("b1", rules);
     }
 
-    @DisplayName("deleteServicePoints делегирует BranchService")
+    @DisplayName("Удаление точек обслуживания выполняет сервис отделений")
     @Test
     void deleteServicePointsDelegates() {
         ConfigurationController controller = controller();
@@ -131,7 +131,7 @@ class ConfigurationControllerTest {
         verify(controller.branchService).deleteServicePoints("b1", ids);
     }
 
-    @DisplayName("setAutoCallModeOfBranchOn делегирует включение автообзвона")
+    @DisplayName("Включение автообзвона отделения выполняет сервис визитов")
     @Test
     void setAutoCallModeOnDelegates() {
         ConfigurationController controller = controller();
@@ -139,7 +139,7 @@ class ConfigurationControllerTest {
         verify(controller.visitService).setAutoCallModeOfBranch("b1", true);
     }
 
-    @DisplayName("setAutoCallModeOfBranchOff делегирует отключение автообзвона")
+    @DisplayName("Отключение автообзвона отделения выполняет сервис визитов")
     @Test
     void setAutoCallModeOffDelegates() {
         ConfigurationController controller = controller();
@@ -147,7 +147,7 @@ class ConfigurationControllerTest {
         verify(controller.visitService).setAutoCallModeOfBranch("b1", false);
     }
 
-    @DisplayName("addUpdateQueues делегирует BranchService")
+    @DisplayName("Добавление или обновление очередей выполняет сервис отделений")
     @Test
     void addUpdateQueuesDelegates() {
         ConfigurationController controller = controller();
@@ -156,7 +156,7 @@ class ConfigurationControllerTest {
         verify(controller.branchService).addUpdateQueues("b1", queues, true);
     }
 
-    @DisplayName("deleteQueues делегирует BranchService")
+    @DisplayName("Удаление очередей выполняет сервис отделений")
     @Test
     void deleteQueuesDelegates() {
         ConfigurationController controller = controller();

--- a/src/test/unit/java/ru/aritmos/api/EntrypointControllerTest.java
+++ b/src/test/unit/java/ru/aritmos/api/EntrypointControllerTest.java
@@ -20,7 +20,7 @@ import ru.aritmos.service.VisitService;
 
 class EntrypointControllerTest {
 
-    @DisplayName("getAllAvailableServices возвращает список доступных услуг")
+    @DisplayName("Получение доступных услуг возвращает полный список")
     @Test
     void getAllAvailableServicesReturnsList() {
         Services services = mock(Services.class);
@@ -45,7 +45,7 @@ class EntrypointControllerTest {
         return controller;
     }
 
-    @DisplayName("createVirtualVisit делегирует создание визита сервису")
+    @DisplayName("Создание виртуального визита выполняет сервис визитов")
     @Test
     void createVirtualVisitDelegatesToService() throws Exception {
         EntrypointController controller = controller();
@@ -60,7 +60,7 @@ class EntrypointControllerTest {
         assertSame(visit, controller.createVirtualVisit("b1", "sp1", ids, "sid"));
     }
 
-    @DisplayName("createVisit делегирует сервису при пустой сегментации")
+    @DisplayName("Создание визита без сегментации выполняет сервис визитов")
     @Test
     void createVisitDelegatesToServiceWhenSegmentationEmpty() throws Exception {
         EntrypointController controller = controller();
@@ -75,7 +75,7 @@ class EntrypointControllerTest {
         assertSame(visit, controller.createVisit("b1", "e1", ids, false, null));
     }
 
-    @DisplayName("createVisit делегирует сервису при наличии сегментации")
+    @DisplayName("Создание визита с сегментацией выполняет сервис визитов")
     @Test
     void createVisitDelegatesToServiceWhenSegmentationProvided() throws Exception {
         EntrypointController controller = controller();
@@ -90,7 +90,7 @@ class EntrypointControllerTest {
         assertSame(visit, controller.createVisit("b1", "e1", ids, false, "seg"));
     }
 
-    @DisplayName("createVisit с объектом параметров делегирует сервису")
+    @DisplayName("Создание визита с объектом параметров выполняет сервис визитов")
     @Test
     void createVisitWithParametersDelegates() throws Exception {
         EntrypointController controller = controller();
@@ -108,7 +108,7 @@ class EntrypointControllerTest {
         assertSame(visit, controller.createVisit("b1", "e1", params, true, null));
     }
 
-    @DisplayName("createVisit с параметрами делегирует сервису при переданной сегментации")
+    @DisplayName("Создание визита с параметрами и сегментацией выполняет сервис визитов")
     @Test
     void createVisitWithParametersDelegatesWithSegmentation() throws Exception {
         EntrypointController controller = controller();
@@ -126,7 +126,7 @@ class EntrypointControllerTest {
         assertSame(visit, controller.createVisit("b1", "e1", params, true, "seg"));
     }
 
-    @DisplayName("createVisitFromReception делегирует сервису без сегментации")
+    @DisplayName("Создание визита из приёмной без сегментации выполняет сервис визитов")
     @Test
     void createVisitFromReceptionDelegatesWithoutSegmentation() throws Exception {
         EntrypointController controller = controller();
@@ -147,7 +147,7 @@ class EntrypointControllerTest {
             .createVisitFromReception("b1", "p1", params, true, "sid");
     }
 
-    @DisplayName("createVisitFromReception делегирует сервису с сегментацией")
+    @DisplayName("Создание визита из приёмной с сегментацией выполняет сервис визитов")
     @Test
     void createVisitFromReceptionDelegatesWithSegmentation() throws Exception {
         EntrypointController controller = controller();
@@ -168,7 +168,7 @@ class EntrypointControllerTest {
             .createVisitFromReception("b1", "p1", params, false, "seg", "sid");
     }
 
-    @DisplayName("setParameterMap обновляет визит и делегирует сохранение")
+    @DisplayName("Обновление параметров визита сохраняет изменения через сервис")
     @Test
     void setParameterMapUpdatesVisitAndDelegates() {
         EntrypointController controller = controller();
@@ -184,7 +184,7 @@ class EntrypointControllerTest {
             .updateVisit(visit, "VISIT_SET_PARAMETER_MAP", controller.visitService);
     }
 
-    @DisplayName("getAllServices делегирует загрузку сервису Services")
+    @DisplayName("Получение всех услуг обращается к агрегирующему сервису")
     @Test
     void getAllServicesDelegatesToServices() {
         EntrypointController controller = controller();

--- a/src/test/unit/java/ru/aritmos/api/KeyCloakControllerTest.java
+++ b/src/test/unit/java/ru/aritmos/api/KeyCloakControllerTest.java
@@ -12,7 +12,7 @@ import ru.aritmos.keycloack.service.KeyCloackClient;
 
 class KeyCloakControllerTest {
 
-    @DisplayName("Auth делегирует авторизацию клиенту Keycloak")
+    @DisplayName("Авторизация делегируется клиенту Keycloak")
     @Test
     void authDelegatesToClient() {
         KeyCloakController controller = new KeyCloakController();
@@ -27,7 +27,7 @@ class KeyCloakControllerTest {
         verify(client).Auth(credentials);
     }
 
-    @DisplayName("DeleteSession делегирует завершение сессии клиенту Keycloak")
+    @DisplayName("Удаление сессии делегируется клиенту Keycloak")
     @Test
     void deleteSessionDelegatesToClient() {
         KeyCloakController controller = new KeyCloakController();

--- a/src/test/unit/java/ru/aritmos/api/ManagementControllerTest.java
+++ b/src/test/unit/java/ru/aritmos/api/ManagementControllerTest.java
@@ -21,7 +21,7 @@ import ru.aritmos.keycloack.service.KeyCloackClient;
 
 class ManagementControllerTest {
 
-    @DisplayName("getBranch возвращает найденное отделение")
+    @DisplayName("Запрос отделения возвращает найденную запись")
     @Test
     void getBranchReturnsBranch() {
         BranchService branchService = mock(BranchService.class);
@@ -33,7 +33,7 @@ class ManagementControllerTest {
         assertSame(branch, controller.getBranch("b1"));
     }
 
-    @DisplayName("getBranch выбрасывает 404 при отсутствии отделения")
+    @DisplayName("Запрос отделения выбрасывает 404 при отсутствии записи")
     @Test
     void getBranchThrowsNotFound() {
         BranchService branchService = mock(BranchService.class);
@@ -45,7 +45,7 @@ class ManagementControllerTest {
         assertThrows(HttpStatusException.class, () -> controller.getBranch("b1"));
     }
 
-    @DisplayName("getBranches без пользователя возвращает все отделения")
+    @DisplayName("Запрос списка отделений без пользователя возвращает все записи")
     @Test
     void getBranchesWithoutUserReturnsAll() {
         BranchService branchService = mock(BranchService.class);
@@ -58,7 +58,7 @@ class ManagementControllerTest {
         verify(branchService).getBranches();
     }
 
-    @DisplayName("getBranches с неизвестным пользователем возвращает все отделения")
+    @DisplayName("Запрос списка отделений с неизвестным пользователем возвращает все записи")
     @Test
     void getBranchesWithUnknownUserFallsBackToAll() {
         BranchService branchService = mock(BranchService.class);
@@ -72,7 +72,7 @@ class ManagementControllerTest {
         assertSame(branches, controller.getBranches("u1"));
     }
 
-    @DisplayName("getBranches для администратора возвращает весь список")
+    @DisplayName("Запрос списка отделений для администратора возвращает все записи")
     @Test
     void getBranchesForAdminВозвращаетВсеОтделения() {
         BranchService branchService = mock(BranchService.class);
@@ -97,7 +97,7 @@ class ManagementControllerTest {
         assertEquals(branches, result);
     }
 
-    @DisplayName("getBranches фильтрует отделения доступом пользователя")
+    @DisplayName("Запрос списка отделений фильтрует данные по доступу пользователя")
     @Test
     void getBranchesФильтруетДоступныеОтделенияДляПользователя() {
         BranchService branchService = mock(BranchService.class);
@@ -135,7 +135,7 @@ class ManagementControllerTest {
         assertFalse(result.containsKey("b2"));
     }
 
-    @DisplayName("getTinyBranches возвращает список Tiny-отделений")
+    @DisplayName("Запрос компактного списка отделений возвращает упрощённое представление")
     @Test
     void getTinyBranchesReturnsMappedList() {
         BranchService branchService = mock(BranchService.class);

--- a/src/test/unit/java/ru/aritmos/api/ServicePointControllerGetServicePointTest.java
+++ b/src/test/unit/java/ru/aritmos/api/ServicePointControllerGetServicePointTest.java
@@ -67,7 +67,7 @@ class ServicePointControllerGetServicePointTest {
         verify(visitService).getUsers("branch-1");
     }
 
-    @DisplayName("Возвращает пустой Optional при отсутствии точки обслуживания")
+    @DisplayName("Возвращает пустой результат при отсутствии точки обслуживания")
     @Test
     void returnsEmptyWhenServicePointIsMissing() {
         LOG.info("Шаг 1: подготавливаем пустую карту точек обслуживания");

--- a/src/test/unit/java/ru/aritmos/api/ServicePointControllerTest.java
+++ b/src/test/unit/java/ru/aritmos/api/ServicePointControllerTest.java
@@ -41,7 +41,7 @@ class ServicePointControllerTest {
         return controller;
     }
 
-    @DisplayName("getFreeServicePoints делегирует загрузку свободных точек сервису визитов")
+    @DisplayName("Получение свободных точек делегирует загрузку сервису визитов")
     @Test
     void getFreeServicePointsDelegatesToVisitService() {
         ServicePointController controller = controller();
@@ -52,7 +52,7 @@ class ServicePointControllerTest {
         verify(controller.visitService).getStringServicePointHashMap("b1");
     }
 
-    @DisplayName("getUsersOfBranch получает сотрудников через BranchService")
+    @DisplayName("Запрос сотрудников отделения выполняется через сервис отделений")
     @Test
     void getUsersOfBranchUsesBranchService() {
         ServicePointController controller = controller();
@@ -65,7 +65,7 @@ class ServicePointControllerTest {
         verify(controller.branchService).getUsers("b1");
     }
 
-    @DisplayName("changeUserWorkprofile делегирует смену рабочего профиля BranchService")
+    @DisplayName("Смена рабочего профиля сотрудника выполняется сервисом отделений")
     @Test
     void changeUserWorkprofileDelegates() {
         ServicePointController controller = controller();
@@ -76,7 +76,7 @@ class ServicePointControllerTest {
         verify(controller.branchService).changeUserWorkProfileInServicePoint("b1", "sp1", "wp1");
     }
 
-    @DisplayName("openServicePoint делегирует открытие точки BranchService")
+    @DisplayName("Открытие точки обслуживания выполняется сервисом отделений")
     @Test
     void openServicePointDelegates() throws IOException {
         ServicePointController controller = controller();
@@ -87,7 +87,7 @@ class ServicePointControllerTest {
         verify(controller.branchService).openServicePoint("b1", "u1", "sp1", "wp1", controller.visitService);
     }
 
-    @DisplayName("closeServicePoint делегирует закрытие точки BranchService")
+    @DisplayName("Закрытие точки обслуживания выполняется сервисом отделений")
     @Test
     void closeServicePointDelegates() {
         ServicePointController controller = controller();
@@ -98,7 +98,7 @@ class ServicePointControllerTest {
                 eq(false), isNull(), eq(false), eq(""));
     }
 
-    @DisplayName("getPrinters запрашивает список принтеров через VisitService")
+    @DisplayName("Получение списка принтеров выполняется сервисом визитов")
     @Test
     void getPrintersDelegates() {
         ServicePointController controller = controller();
@@ -107,7 +107,7 @@ class ServicePointControllerTest {
         assertEquals(printers, controller.getPrinters("b1"));
     }
 
-    @DisplayName("getQueues запрашивает очереди через VisitService")
+    @DisplayName("Запрос списка очередей выполняется сервисом визитов")
     @Test
     void getQueuesDelegates() {
         ServicePointController controller = controller();
@@ -116,7 +116,7 @@ class ServicePointControllerTest {
         assertEquals(queues, controller.getQueues("b1"));
     }
 
-    @DisplayName("getFullQueues возвращает очереди с деталями через VisitService")
+    @DisplayName("Запрос очередей с деталями обрабатывает сервис визитов")
     @Test
     void getFullQueuesDelegates() {
         ServicePointController controller = controller();
@@ -125,7 +125,7 @@ class ServicePointControllerTest {
         assertEquals(queues, controller.getFullQueues("b1"));
     }
 
-    @DisplayName("getServicePoints преобразует точки обслуживания к Tiny-модели")
+    @DisplayName("Загрузка точек обслуживания преобразует их в упрощенную модель")
     @Test
     void getServicePointsMapsToTiny() {
         ServicePointController controller = controller();
@@ -138,7 +138,7 @@ class ServicePointControllerTest {
         assertEquals("sp1", result.get(0).getId());
     }
 
-    @DisplayName("getDetailedServicePoints делегирует возврат детальной карты точек")
+    @DisplayName("Получение детальной информации о точках выполняет сервис визитов")
     @Test
     void getDetailedServicePointsDelegates() {
         ServicePointController controller = controller();
@@ -148,7 +148,7 @@ class ServicePointControllerTest {
         assertEquals(List.of(sp), controller.getDetailedServicePoints("b1"));
     }
 
-    @DisplayName("getServicePointsByUserName возвращает точку по имени пользователя")
+    @DisplayName("Поиск точки по имени пользователя возвращает соответствующий объект")
     @Test
     void getServicePointsByUserNameReturnsPoint() {
         ServicePointController controller = controller();
@@ -164,7 +164,7 @@ class ServicePointControllerTest {
         assertEquals(sp, result.get());
     }
 
-    @DisplayName("getAllWorkingUsersOfBranch делегирует выборку работающих сотрудников")
+    @DisplayName("Запрос работающих сотрудников отделения выполняет сервис визитов")
     @Test
     void getAllWorkingUsersDelegates() {
         ServicePointController controller = controller();
@@ -175,7 +175,7 @@ class ServicePointControllerTest {
         verify(controller.visitService).getAllWorkingUsers("b1");
     }
 
-    @DisplayName("глобальный getServicePointsByUserName ищет точку через BranchService")
+    @DisplayName("Глобальный поиск точки по имени пользователя выполняет сервис отделений")
     @Test
     void globalGetServicePointByUserNameDelegates() {
         ServicePointController controller = controller();
@@ -191,7 +191,7 @@ class ServicePointControllerTest {
         assertTrue(result.isPresent());
     }
 
-    @DisplayName("getUserByUserName возвращает пользователя из VisitService")
+    @DisplayName("Поиск пользователя по имени возвращает данные сервиса визитов")
     @Test
     void getUserByUserNameReturnsUser() {
         ServicePointController controller = controller();
@@ -205,7 +205,7 @@ class ServicePointControllerTest {
         assertEquals(user, result.get());
     }
 
-    @DisplayName("getWorkProfiles делегирует получение профилей VisitService")
+    @DisplayName("Запрос рабочих профилей выполняет сервис визитов")
     @Test
     void getWorkProfilesDelegates() {
         ServicePointController controller = controller();
@@ -214,7 +214,7 @@ class ServicePointControllerTest {
         assertEquals(profiles, controller.getWorkProfiles("b1"));
     }
 
-    @DisplayName("logoutUser закрывает точку через BranchService")
+    @DisplayName("Выход пользователя закрывает точку обслуживания средствами сервиса отделений")
     @Test
     void logoutUserDelegates() {
         ServicePointController controller = controller();
@@ -224,7 +224,7 @@ class ServicePointControllerTest {
                 eq(false), isNull(), eq(false), eq(""));
     }
 
-    @DisplayName("getVisits с лимитом делегирует загрузку визитов VisitService")
+    @DisplayName("Запрос ограниченного списка визитов выполняет сервис визитов")
     @Test
     void getVisitsWithLimitDelegates() {
         ServicePointController controller = controller();
@@ -233,7 +233,7 @@ class ServicePointControllerTest {
         assertEquals(1, controller.getVisits("b1", "q1", 5L).size());
     }
 
-    @DisplayName("getVisits без лимита делегирует загрузку VisitService")
+    @DisplayName("Запрос полного списка визитов выполняет сервис визитов")
     @Test
     void getVisitsDelegates() {
         ServicePointController controller = controller();
@@ -242,7 +242,7 @@ class ServicePointControllerTest {
         assertEquals(1, controller.getVisits("b1", "q1").size());
     }
 
-    @DisplayName("getAllVisits возвращает карту визитов VisitService")
+    @DisplayName("Запрос всех визитов возвращает карту сервиса визитов")
     @Test
     void getAllVisitsDelegates() {
         ServicePointController controller = controller();
@@ -251,7 +251,7 @@ class ServicePointControllerTest {
         assertEquals(visits, controller.getAllVisits("b1"));
     }
 
-    @DisplayName("getVisit делегирует поиск визита VisitService")
+    @DisplayName("Поиск конкретного визита выполняет сервис визитов")
     @Test
     void getVisitDelegates() {
         ServicePointController controller = controller();
@@ -260,7 +260,7 @@ class ServicePointControllerTest {
         assertEquals(visit, controller.getVisit("b1", "v1"));
     }
 
-    @DisplayName("getVisitsByStatuses делегирует фильтрацию статусов VisitService")
+    @DisplayName("Фильтрация визитов по статусам выполняется сервисом визитов")
     @Test
     void getVisitsByStatusesDelegates() {
         ServicePointController controller = controller();
@@ -270,7 +270,7 @@ class ServicePointControllerTest {
         assertEquals(visits, controller.getVisitsByStatuses("b1", List.of("NEW")));
     }
 
-    @DisplayName("visitCallWithMaximalWaitingTime использует VisitService для поиска визита")
+    @DisplayName("Вызов визита с максимальным ожиданием выполняет сервис визитов")
     @Test
     void visitCallWithMaxWaitingDelegates() {
         ServicePointController controller = controller();
@@ -280,7 +280,7 @@ class ServicePointControllerTest {
         assertEquals(visit, controller.visitCallWithMaximalWaitingTime("b1", "sp1"));
     }
 
-    @DisplayName("getVisit по очереди возвращает найденный визит")
+    @DisplayName("Поиск визита в очереди возвращает найденный объект")
     @Test
     void getVisitFromQueueReturnsMatch() {
         ServicePointController controller = controller();
@@ -293,7 +293,7 @@ class ServicePointControllerTest {
         verify(controller.visitService).getVisits("b1", "q1");
     }
 
-    @DisplayName("getVisit по очереди выбрасывает 404 при отсутствии визита")
+    @DisplayName("Поиск визита в очереди выбрасывает 404 при отсутствии результата")
     @Test
     void getVisitFromQueueThrowsWhenMissing() {
         ServicePointController controller = controller();
@@ -305,7 +305,7 @@ class ServicePointControllerTest {
         assertEquals(HttpStatus.NOT_FOUND, exception.getStatus());
     }
 
-    @DisplayName("callVisit делегирует вызов визита VisitService")
+    @DisplayName("Обращение к вызову визита выполняется сервисом визитов")
     @Test
     void callVisitDelegatesToService() {
         ServicePointController controller = controller();
@@ -315,7 +315,7 @@ class ServicePointControllerTest {
         assertEquals(visit, controller.callVisit("b1", "sp1", "v1"));
     }
 
-    @DisplayName("visitCallForConfirm возвращает результат VisitService")
+    @DisplayName("Повторный вызов для подтверждения возвращает результат сервиса визитов")
     @Test
     void visitCallForConfirmUsesServiceResult() {
         ServicePointController controller = controller();
@@ -327,7 +327,7 @@ class ServicePointControllerTest {
         assertEquals(expected, controller.visitCallForConfirm("b1", "sp1", visit));
     }
 
-    @DisplayName("visitCallForConfirmByVisitId загружает визит и делегирует подтверждение")
+    @DisplayName("Подтверждение визита по идентификатору загружает данные и делегируется сервису")
     @Test
     void visitCallForConfirmByIdLoadsVisitFirst() {
         ServicePointController controller = controller();
@@ -341,7 +341,7 @@ class ServicePointControllerTest {
         verify(controller.visitService).getVisit("b1", "v1");
     }
 
-    @DisplayName("visitCallForConfirmMaxWaitingTime использует VisitService")
+    @DisplayName("Подтверждение визита с ограничением ожидания выполняет сервис визитов")
     @Test
     void visitCallForConfirmMaxWaitingDelegates() {
         ServicePointController controller = controller();
@@ -352,7 +352,7 @@ class ServicePointControllerTest {
         assertEquals(expected, controller.visitCallForConfirmMaxWaitingTime("b1", "sp1"));
     }
 
-    @DisplayName("visitCall с несколькими очередями делегирует выбор визита")
+    @DisplayName("Вызов визита среди нескольких очередей делегирует выбор сервису")
     @Test
     void visitCallFromQueuesDelegates() {
         ServicePointController controller = controller();
@@ -364,7 +364,7 @@ class ServicePointControllerTest {
         assertEquals(expected, controller.visitCall("b1", "sp1", queueIds));
     }
 
-    @DisplayName("visitCallForConfirmMaxWaitingTime с очередями делегирует выбор визита")
+    @DisplayName("Подтверждение с максимальным ожиданием по нескольким очередям делегирует выбор сервису")
     @Test
     void visitCallFromQueuesWithConfirmationDelegates() {
         ServicePointController controller = controller();
@@ -377,7 +377,7 @@ class ServicePointControllerTest {
             expected, controller.visitCallForConfirmMaxWaitingTime("b1", "sp1", queueIds));
     }
 
-    @DisplayName("visitNoShow делегирует обработку VisitService")
+    @DisplayName("Фиксация неявки клиента выполняется сервисом визитов")
     @Test
     void visitNoShowDelegatesToService() {
         ServicePointController controller = controller();
@@ -388,7 +388,7 @@ class ServicePointControllerTest {
         assertEquals(expected, controller.visitNoShow("b1", "sp1", visit));
     }
 
-    @DisplayName("visitCallNoShow загружает визит и делегирует обработку отсутствия клиента")
+    @DisplayName("Повторный вызов отсутствующего клиента загружает визит и делегирует обработку сервису")
     @Test
     void visitCallNoShowRetrievesVisit() {
         ServicePointController controller = controller();
@@ -401,7 +401,7 @@ class ServicePointControllerTest {
         verify(controller.visitService).getVisit("b1", "v1");
     }
 
-    @DisplayName("visitReCallForConfirm делегирует повторный вызов VisitService")
+    @DisplayName("Повторное приглашение на подтверждение выполняется сервисом визитов")
     @Test
     void visitReCallForConfirmDelegates() {
         ServicePointController controller = controller();
@@ -411,7 +411,7 @@ class ServicePointControllerTest {
         assertEquals(visit, controller.visitReCallForConfirm("b1", "sp1", visit));
     }
 
-    @DisplayName("visitReCallForConfirm по идентификатору загружает визит из VisitService")
+    @DisplayName("Повторное приглашение по идентификатору загружает визит через сервис визитов")
     @Test
     void visitReCallForConfirmByIdLoadsVisit() {
         ServicePointController controller = controller();
@@ -423,7 +423,7 @@ class ServicePointControllerTest {
         verify(controller.visitService).getVisit("b1", "v1");
     }
 
-    @DisplayName("visitConfirm делегирует подтверждение VisitService")
+    @DisplayName("Подтверждение визита выполняется сервисом визитов")
     @Test
     void visitConfirmDelegates() {
         ServicePointController controller = controller();
@@ -433,7 +433,7 @@ class ServicePointControllerTest {
         assertEquals(visit, controller.visitConfirm("b1", "sp1", visit));
     }
 
-    @DisplayName("visitConfirm по идентификатору загружает визит и делегирует подтверждение")
+    @DisplayName("Подтверждение визита по идентификатору загружает данные и передает их сервису")
     @Test
     void visitConfirmByIdDelegates() {
         ServicePointController controller = controller();
@@ -445,7 +445,7 @@ class ServicePointControllerTest {
         verify(controller.visitService).getVisit("b1", "v1");
     }
 
-    @DisplayName("cancelAutoCallModeOfServicePoint делегирует отмену автообзвона VisitService")
+    @DisplayName("Отключение автообзвона точки выполняется сервисом визитов")
     @Test
     void cancelAutoCallDelegates() {
         ServicePointController controller = controller();
@@ -456,7 +456,7 @@ class ServicePointControllerTest {
         assertEquals(expected, controller.cancelAutoCallModeOfServicePoint("b1", "sp1"));
     }
 
-    @DisplayName("startAutoCallModeOfServicePoint включает автообзвон отделения и точки")
+    @DisplayName("Включение автообзвона охватывает отделение и конкретную точку")
     @Test
     void startAutoCallEnablesBranchAndPoint() {
         ServicePointController controller = controller();
@@ -469,7 +469,7 @@ class ServicePointControllerTest {
         verify(controller.visitService).startAutoCallModeOfServicePoint("b1", "sp1");
     }
 
-    @DisplayName("getOutcomes возвращает настроенные исходы из BranchService")
+    @DisplayName("Запрос исходов выполняется сервисом отделений")
     @Test
     void getOutcomesReturnsConfiguredMap() {
         ServicePointController controller = controller();
@@ -488,7 +488,7 @@ class ServicePointControllerTest {
         verify(controller.branchService).getBranch("b1");
     }
 
-    @DisplayName("getOutcomes выбрасывает 404 при отсутствии услуги")
+    @DisplayName("Запрос исходов возвращает 404 при отсутствии услуги")
     @Test
     void getOutcomesThrowsWhenServiceMissing() {
         ServicePointController controller = controller();
@@ -502,7 +502,7 @@ class ServicePointControllerTest {
         verify(controller.eventService).send(eq("*"), eq(false), any());
     }
 
-    @DisplayName("visitCallMaxLifeTime делегирует стратегию максимального времени ожидания")
+    @DisplayName("Вызов визита по стратегии максимального времени делегируется сервису")
     @Test
     void visitCallMaxLifeTimeDelegatesToService() {
         ServicePointController controller = controller();
@@ -515,7 +515,7 @@ class ServicePointControllerTest {
         verify(controller.visitService).visitCallWithMaxLifeTime("b1", "sp1");
     }
 
-    @DisplayName("visitCallMaxLifeTime с очередями использует VisitService")
+    @DisplayName("Вызов визита по стратегии максимального времени для очередей выполняет сервис визитов")
     @Test
     void visitCallMaxLifeTimeFromQueuesDelegatesToService() {
         ServicePointController controller = controller();
@@ -529,7 +529,7 @@ class ServicePointControllerTest {
         verify(controller.visitService).visitCallWithMaxLifeTime("b1", "sp1", queueIds);
     }
 
-    @DisplayName("visitCallForConfirmMaxLifeTime делегирует стратегию максимального времени подтверждения")
+    @DisplayName("Подтверждение визита по стратегии максимального времени делегируется сервису")
     @Test
     void visitCallForConfirmMaxLifeTimeDelegatesToService() {
         ServicePointController controller = controller();
@@ -543,7 +543,7 @@ class ServicePointControllerTest {
         verify(controller.visitService).visitCallForConfirmWithMaxLifeTime("b1", "sp1");
     }
 
-    @DisplayName("visitCallForConfirmMaxLifeTime с очередями использует VisitService")
+    @DisplayName("Подтверждение визита по стратегии максимального времени для очередей выполняет сервис визитов")
     @Test
     void visitCallForConfirmMaxLifeTimeFromQueuesDelegatesToService() {
         ServicePointController controller = controller();
@@ -558,7 +558,7 @@ class ServicePointControllerTest {
         verify(controller.visitService).visitCallForConfirmWithMaxLifeTime("b1", "sp1", queueIds);
     }
 
-    @DisplayName("getDeliveredService фильтрует выдаваемые услуги по идентификатору")
+    @DisplayName("Получение фактической услуги фильтрует данные по идентификатору")
     @Test
     void getDeliveredServiceFiltersByServiceId() {
         ServicePointController controller = controller();
@@ -581,7 +581,7 @@ class ServicePointControllerTest {
         verify(controller.branchService).getBranch("b1");
     }
 
-    @DisplayName("getDeliveredServiceOfCurrentService делегирует загрузку VisitService")
+    @DisplayName("Получение фактических услуг текущей услуги выполняет сервис визитов")
     @Test
     void getDeliveredServiceOfCurrentServiceDelegatesToVisitService() {
         ServicePointController controller = controller();
@@ -594,7 +594,7 @@ class ServicePointControllerTest {
         verify(controller.visitService).getDeliveredServices("b1", "sp1");
     }
 
-    @DisplayName("getServicesByWorkProfileId делегирует выборку BranchService")
+    @DisplayName("Запрос услуг по рабочему профилю выполняет сервис отделений")
     @Test
     void getServicesByWorkProfileIdDelegatesToBranchService() {
         ServicePointController controller = controller();
@@ -607,7 +607,7 @@ class ServicePointControllerTest {
         verify(controller.branchService).getServicesByWorkProfileId("b1", "wp1");
     }
 
-    @DisplayName("getServicesByQueueId делегирует выборку BranchService")
+    @DisplayName("Запрос услуг по очереди выполняет сервис отделений")
     @Test
     void getServicesByQueueIdDelegatesToBranchService() {
         ServicePointController controller = controller();
@@ -620,7 +620,7 @@ class ServicePointControllerTest {
         verify(controller.branchService).getServicesByQueueId("b1", "q1");
     }
 
-    @DisplayName("getDeliveredServicesByBranchId запрашивает BranchService")
+    @DisplayName("Получение фактических услуг отделения выполняет сервис отделений")
     @Test
     void getDeliveredServicesByBranchIdDelegatesToBranchService() {
         ServicePointController controller = controller();
@@ -633,7 +633,7 @@ class ServicePointControllerTest {
         verify(controller.branchService).getDeliveredServicesByBranchId("b1");
     }
 
-    @DisplayName("addDeliveredService делегирует добавление VisitService")
+    @DisplayName("Добавление фактической услуги выполняет сервис визитов")
     @Test
     void addDeliveredServiceDelegatesToVisitService() {
         ServicePointController controller = controller();
@@ -646,7 +646,7 @@ class ServicePointControllerTest {
         verify(controller.visitService).addDeliveredService("b1", "sp1", "ds1");
     }
 
-    @DisplayName("addServices последовательно вызывает VisitService")
+    @DisplayName("Пакетное добавление услуг выполняется последовательными вызовами сервиса визитов")
     @Test
     void addServicesInvokesVisitServiceSequentially() {
         ServicePointController controller = controller();
@@ -662,7 +662,7 @@ class ServicePointControllerTest {
         verify(controller.visitService).addService("b1", "sp1", "s2");
     }
 
-    @DisplayName("deleteVisit удаляет найденный визит через VisitService")
+    @DisplayName("Удаление найденного визита выполняется сервисом визитов")
     @Test
     void deleteVisitRemovesVisitWhenFound() {
         ServicePointController controller = controller();
@@ -675,7 +675,7 @@ class ServicePointControllerTest {
         verify(controller.visitService).deleteVisit(visit);
     }
 
-    @DisplayName("deleteVisit выбрасывает 404 при отсутствии визита")
+    @DisplayName("Удаление визита возвращает 404 при отсутствии записи")
     @Test
     void deleteVisitThrowsWhenMissing() {
         ServicePointController controller = controller();

--- a/src/test/unit/java/ru/aritmos/api/ServicePointControllerVisitTransferTest.java
+++ b/src/test/unit/java/ru/aritmos/api/ServicePointControllerVisitTransferTest.java
@@ -62,7 +62,7 @@ class ServicePointControllerVisitTransferTest {
         return branch;
     }
 
-    @DisplayName("visitTransferFromQueue по идентификатору инвертирует флаг вставки")
+    @DisplayName("Перенос визита по идентификатору из очереди инвертирует флаг вставки")
     @Test
     void visitTransferFromQueueByIdInvertsAppendFlag() {
         LOG.info("Шаг 1: настраиваем окружение для перевода визита по идентификатору");
@@ -114,7 +114,7 @@ class ServicePointControllerVisitTransferTest {
         verify(visitService).getVisit("branch-1", "visit-7");
     }
 
-    @DisplayName("visitTransferFromQueue по идентификатору возвращает 404 при отсутствии очереди")
+    @DisplayName("Перенос визита по идентификатору из очереди возвращает 404 при отсутствии очереди")
     @Test
     void visitTransferFromQueueByIdFailsWhenQueueMissing() {
         LOG.info("Шаг 1: создаем отделение без целевой очереди");
@@ -139,7 +139,7 @@ class ServicePointControllerVisitTransferTest {
         verify(visitService, never()).getVisit(anyString(), anyString());
     }
 
-    @DisplayName("visitTransferFromQueue с телом запроса инвертирует флаг вставки")
+    @DisplayName("Перенос визита по телу запроса из очереди инвертирует флаг вставки")
     @Test
     void visitTransferFromQueueWithBodyRespectsAppendInversion() {
         LOG.info("Шаг 1: настраиваем отделение и подготовленный визит");
@@ -188,7 +188,7 @@ class ServicePointControllerVisitTransferTest {
         assertTrue(appendCaptor.getValue(), "Флаг должен быть развернут контроллером");
     }
 
-    @DisplayName("visitTransferFromQueue с индексом передает позицию без искажений")
+    @DisplayName("Перенос визита из очереди по индексу передает позицию без искажений")
     @Test
     void visitTransferFromQueueWithIndexPassesExactPosition() {
         LOG.info("Шаг 1: подготавливаем отделение, визит и индекс");
@@ -237,7 +237,7 @@ class ServicePointControllerVisitTransferTest {
         assertEquals(5, indexCaptor.getValue());
     }
 
-    @DisplayName("visitTransferFromQueue для внешнего сервиса передает метаданные без изменений")
+    @DisplayName("Перенос визита из очереди во внешнюю службу передает метаданные без изменений")
     @Test
     void visitTransferFromQueueExternalServicePropagatesMetadata() {
         LOG.info("Шаг 1: готовим отделение и данные внешней службы");
@@ -291,7 +291,7 @@ class ServicePointControllerVisitTransferTest {
         assertSame(response, actual);
     }
 
-    @DisplayName("visitTransferFromQueueToServicePointPool через внешнюю службу проверяет точку обслуживания")
+    @DisplayName("Перенос визита в сервисный пул через внешнюю службу проверяет наличие точки обслуживания")
     @Test
     void visitTransferFromQueueToServicePointPoolExternalServiceValidatesServicePoint() {
         LOG.info("Шаг 1: готовим отделение и сервисную точку");
@@ -346,7 +346,7 @@ class ServicePointControllerVisitTransferTest {
         assertSame(response, actual);
     }
 
-    @DisplayName("visitTransferFromQueueToServicePointPool через внешнюю службу возвращает 404 без точки")
+    @DisplayName("Перенос визита в сервисный пул через внешнюю службу возвращает 404 без точки обслуживания")
     @Test
     void visitTransferFromQueueToServicePointPoolExternalServiceFailsWithoutServicePoint() {
         LOG.info("Шаг 1: создаем отделение без зарегистрированной точки обслуживания");
@@ -380,7 +380,7 @@ class ServicePointControllerVisitTransferTest {
         verify(eventService).send(eq("*"), eq(false), any(Event.class));
     }
 
-    @DisplayName("visitTransferFromQueue по идентификатору визита делегирует поиск визита и индекса")
+    @DisplayName("Перенос визита из очереди по идентификатору делегирует поиск визита и индекса")
     @Test
     void visitTransferFromQueueByVisitIdDelegatesIndexAndVisitLookup() {
         LOG.info("Шаг 1: готовим отделение с очередью и визит в хранилище");
@@ -431,7 +431,7 @@ class ServicePointControllerVisitTransferTest {
         verify(visitService).getVisit("branch-idx", "visit-idx");
     }
 
-    @DisplayName("visitTransferFromQueue по идентификатору визита возвращает 404 при отсутствии очереди")
+    @DisplayName("Перенос визита из очереди по идентификатору возвращает 404 при отсутствии очереди")
     @Test
     void visitTransferFromQueueByVisitIdFailsWhenQueueMissing() {
         LOG.info("Шаг 1: создаем отделение без требуемой очереди");
@@ -463,7 +463,7 @@ class ServicePointControllerVisitTransferTest {
         verify(visitService, never()).getVisit(anyString(), anyString());
     }
 
-    @DisplayName("visitTransferFromQueue по визиту возвращает 404 при отсутствии отделения")
+    @DisplayName("Перенос визита из очереди по объекту визита возвращает 404 при отсутствии отделения")
     @Test
     void visitTransferFromQueueByVisitIdFailsWhenBranchMissing() {
         LOG.info("Шаг 1: настраиваем сервис отделений на выброс исключения");
@@ -494,7 +494,7 @@ class ServicePointControllerVisitTransferTest {
         verifyNoInteractions(visitService);
     }
 
-    @DisplayName("visitTransfer из точки обслуживания делегирует флаг вставки сервису")
+    @DisplayName("Перенос визита из точки обслуживания делегирует обработку флага вставки сервису")
     @Test
     void visitTransferFromServicePointDelegatesAppendFlag() {
         LOG.info("Шаг 1: подготавливаем отделение с очередью для перевода из сервиса");
@@ -525,7 +525,7 @@ class ServicePointControllerVisitTransferTest {
         assertSame(expected, actual);
     }
 
-    @DisplayName("visitTransfer из точки обслуживания возвращает 404 при отсутствии очереди")
+    @DisplayName("Перенос визита из точки обслуживания возвращает 404 при отсутствии очереди")
     @Test
     void visitTransferFromServicePointFailsWhenQueueMissing() {
         LOG.info("Шаг 1: создаем отделение без требуемой очереди для перевода");
@@ -550,7 +550,7 @@ class ServicePointControllerVisitTransferTest {
         verifyNoInteractions(visitService);
     }
 
-    @DisplayName("visitTransfer из точки обслуживания возвращает 404 при отсутствии отделения")
+    @DisplayName("Перенос визита из точки обслуживания возвращает 404 при отсутствии отделения")
     @Test
     void visitTransferFromServicePointFailsWhenBranchUnavailable() {
         LOG.info("Шаг 1: подготавливаем сервис отделений к ошибке получения данных");
@@ -575,7 +575,7 @@ class ServicePointControllerVisitTransferTest {
         verifyNoInteractions(visitService);
     }
 
-    @DisplayName("visitBackToServicePointPool делегирует возврат визита в сервисный пул")
+    @DisplayName("Возврат визита в сервисный пул делегирует операцию прикладному сервису")
     @Test
     void visitBackToServicePointPoolDelegatesToService() {
         LOG.info("Шаг 1: формируем отделение с пулом точки обслуживания");
@@ -605,7 +605,7 @@ class ServicePointControllerVisitTransferTest {
         assertSame(expected, actual);
     }
 
-    @DisplayName("visitBackToServicePointPool возвращает 404 при отсутствии пула")
+    @DisplayName("Возврат визита в сервисный пул возвращает 404 при отсутствии пула")
     @Test
     void visitBackToServicePointPoolFailsWhenPoolMissing() {
         LOG.info("Шаг 1: создаем отделение без пула точек обслуживания");
@@ -630,7 +630,7 @@ class ServicePointControllerVisitTransferTest {
         verifyNoInteractions(visitService);
     }
 
-    @DisplayName("visitBackToServicePointPool возвращает 404 при отсутствии отделения")
+    @DisplayName("Возврат визита в сервисный пул возвращает 404 при отсутствии отделения")
     @Test
     void visitBackToServicePointPoolFailsWhenBranchUnavailable() {
         LOG.info("Шаг 1: конфигурируем сервис отделений на выброс исключения при получении отдела");
@@ -655,7 +655,7 @@ class ServicePointControllerVisitTransferTest {
         verifyNoInteractions(visitService);
     }
 
-    @DisplayName("visitTransferToServicePointPool делегирует перевод визита в пул")
+    @DisplayName("Перевод визита в сервисный пул делегирует операцию прикладному сервису")
     @Test
     void visitTransferToServicePointPoolDelegatesToService() {
         LOG.info("Шаг 1: подготавливаем отделение с доступным пулом обслуживания");
@@ -685,7 +685,7 @@ class ServicePointControllerVisitTransferTest {
         assertSame(expected, actual);
     }
 
-    @DisplayName("visitTransferToServicePointPool возвращает 404 при отсутствии пуловой точки")
+    @DisplayName("Перевод визита в сервисный пул возвращает 404 при отсутствии целевой точки")
     @Test
     void visitTransferToServicePointPoolFailsWhenPoolMissing() {
         LOG.info("Шаг 1: создаем отделение без зарегистрированных пулов");
@@ -715,7 +715,7 @@ class ServicePointControllerVisitTransferTest {
         verifyNoInteractions(visitService);
     }
 
-    @DisplayName("visitTransferToServicePointPool возвращает 404 при отсутствии отделения")
+    @DisplayName("Перевод визита в сервисный пул возвращает 404 при отсутствии отделения")
     @Test
     void visitTransferToServicePointPoolFailsWhenBranchUnavailable() {
         LOG.info("Шаг 1: конфигурируем сервис отделений на ошибку при поиске отделения");

--- a/src/test/unit/java/ru/aritmos/clients/ConfigurationClientTest.java
+++ b/src/test/unit/java/ru/aritmos/clients/ConfigurationClientTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test;
 
 class ConfigurationClientTest {
 
-    @DisplayName("Интерфейс аннотирован @Client с ожидаемым URL")
+    @DisplayName("Интерфейс помечен аннотацией клиента с ожидаемым адресом")
     @Test
     void interfaceIsAnnotatedWithClientUsingExpectedUrl() {
         Client annotation = ConfigurationClient.class.getAnnotation(Client.class);
@@ -19,7 +19,7 @@ class ConfigurationClientTest {
         assertEquals("${micronaut.application.configurationURL}", annotation.value());
     }
 
-    @DisplayName("Метод getConfiguration помечен аннотацией @Get")
+    @DisplayName("Метод получения конфигурации помечен аннотацией запроса на чтение (GET)")
     @Test
     void getConfigurationMethodHasGetAnnotation() throws NoSuchMethodException {
         Method method = ConfigurationClient.class.getMethod("getConfiguration");

--- a/src/test/unit/java/ru/aritmos/clients/PrinterClientTest.java
+++ b/src/test/unit/java/ru/aritmos/clients/PrinterClientTest.java
@@ -14,7 +14,7 @@ import ru.aritmos.model.visit.Visit;
 
 class PrinterClientTest {
 
-    @DisplayName("Интерфейс аннотирован как Micronaut-клиент")
+    @DisplayName("Интерфейс помечен клиентской аннотацией фреймворка «Micronaut»")
     @Test
     void interfaceIsAnnotatedAsMicronautClient() {
         Client annotation = PrinterClient.class.getAnnotation(Client.class);
@@ -22,7 +22,7 @@ class PrinterClientTest {
         assertEquals("${micronaut.application.printerServiceURL}", annotation.value());
     }
 
-    @DisplayName("Метод print содержит аннотации повторных попыток и очереди исполнения")
+    @DisplayName("Метод печати содержит аннотации повторных попыток и очереди исполнения")
     @Test
     void printMethodHasRetryAnnotations() throws NoSuchMethodException {
         Method method = PrinterClient.class.getMethod("print", String.class, Boolean.class, Visit.class);

--- a/src/test/unit/java/ru/aritmos/config/LocalNoDockerDataBusClientStubTest.java
+++ b/src/test/unit/java/ru/aritmos/config/LocalNoDockerDataBusClientStubTest.java
@@ -9,7 +9,7 @@ import reactor.core.publisher.Mono;
 
 class LocalNoDockerDataBusClientStubTest {
 
-    @DisplayName("Метод send возвращает заглушенные статус и тип")
+    @DisplayName("Метод `send` возвращает заглушённые статус и тип")
     @Test
     void sendReturnsStubbedStatusAndType() {
         LocalNoDockerDataBusClientStub client = new LocalNoDockerDataBusClientStub();

--- a/src/test/unit/java/ru/aritmos/config/SwaggerYamlCharsetFilterTest.java
+++ b/src/test/unit/java/ru/aritmos/config/SwaggerYamlCharsetFilterTest.java
@@ -27,7 +27,7 @@ class SwaggerYamlCharsetFilterTest {
     private static final Logger LOG = LoggerFactory.getLogger(SwaggerYamlCharsetFilterTest.class);
 
     @Test
-    @DisplayName("Добавление базового заголовка Content-Type для YAML без заголовка и логирование всех шагов")
+    @DisplayName("Добавление базового заголовка `Content-Type` для YAML без заголовка и логирование всех шагов")
     void addsDefaultYamlContentTypeWhenHeaderMissing() {
         LOG.info("Шаг 1: создаём ответ без заголовка Content-Type для YAML-спецификации.");
         MutableHttpResponse<?> response = HttpResponse.ok();
@@ -41,7 +41,7 @@ class SwaggerYamlCharsetFilterTest {
     }
 
     @Test
-    @DisplayName("Добавление кодировки UTF-8 к YAML-ответу без charset при обработке swagger-файла")
+    @DisplayName("Добавление кодировки `UTF-8` к YAML-ответу без charset при обработке swagger-файла")
 
     void appendsCharsetForYamlWithoutEncoding() {
         LOG.info("Шаг 1: подготавливаем ответ с типом application/yaml без charset.");
@@ -70,7 +70,7 @@ class SwaggerYamlCharsetFilterTest {
     }
 
     @Test
-    @DisplayName("Пропуск нерелевантных ответов: не-YAML содержимое и не-YAML запросы остаются неизменными")
+    @DisplayName("Пропуск нерелевантных ответов: запросы и ответы без признаков YAML остаются неизменными")
 
     void skipsNonYamlResponsesAndRequests() {
         LOG.info("Шаг 1: ответ с типом application/json для запроса не к YAML-спецификации.");

--- a/src/test/unit/java/ru/aritmos/docs/CurlCheatsheetGeneratorTest.java
+++ b/src/test/unit/java/ru/aritmos/docs/CurlCheatsheetGeneratorTest.java
@@ -25,7 +25,7 @@ class CurlCheatsheetGeneratorTest {
      * Убеждаемся, что экранирование спецсимволов HTML работает корректно для угловых скобок и
      * амперсанда.
      */
-    @DisplayName("Экранирование HTML заменяет спецсимволы угловых скобок и амперсанда")
+    @DisplayName("Экранирование HTML заменяет спецсимволы угловых скобок и знака амперсанда")
     @Test
     void escapeHtml() throws Exception {
         Method escape = CurlCheatsheetGenerator.class.getDeclaredMethod("escape", String.class);
@@ -38,7 +38,7 @@ class CurlCheatsheetGeneratorTest {
      * Проверяет, что секция контроллера с комментариями «Пример curl» добавляется в итоговый HTML
      * и содержит исходный пример запроса.
      */
-    @DisplayName("Добавление секции контроллера переносит пример curl в HTML")
+    @DisplayName("Добавление секции контроллера переносит пример команды `curl` в итоговый HTML")
     @Test
     void appendControllerSectionAddsExample() throws Exception {
         Path file = Files.createTempFile("Controller", ".java");
@@ -69,7 +69,7 @@ class CurlCheatsheetGeneratorTest {
     /**
      * Убеждаемся, что главный метод создаёт HTML-файл со сведениями из контроллеров.
      */
-    @DisplayName("Главный метод генерирует HTML-шпаргалку по curl-запросам")
+    @DisplayName("Главный метод формирует HTML-шпаргалку по запросам `curl`")
     @Test
     void mainGeneratesCheatsheet() throws Exception {
         Path projectRoot = Paths.get("").toAbsolutePath();
@@ -119,7 +119,7 @@ class CurlCheatsheetGeneratorTest {
      * Проверяет, что генератор извлекает метод и URI из аннотации даже при многострочном описании
      * с параметром {@code uri} на отдельной строке.
      */
-    @DisplayName("Секция контроллера извлекает URI из многострочной аннотации")
+    @DisplayName("Секция контроллера извлекает значение URI из многострочной аннотации")
     @Test
     void appendControllerSectionResolvesUriFromAttributeBlock() throws Exception {
         Path file = Files.createTempFile("ControllerMulti", ".java");

--- a/src/test/unit/java/ru/aritmos/exceptions/BusinessExceptionLocalizationTest.java
+++ b/src/test/unit/java/ru/aritmos/exceptions/BusinessExceptionLocalizationTest.java
@@ -83,7 +83,7 @@ class BusinessExceptionLocalizationTest {
         assertEquals("Visit not found", appender.list.get(0).getFormattedMessage());
     }
 
-    @DisplayName("Заменяет поле «message» в теле ответа типа Map")
+    @DisplayName("Заменяет поле `message` в теле ответа-словаря")
     @Test
     void replacesMessageFieldInMapResponseBody() {
         BusinessExceptionLocalizationProperties properties = new BusinessExceptionLocalizationProperties();

--- a/src/test/unit/java/ru/aritmos/handlers/EventHandlerContextTest.java
+++ b/src/test/unit/java/ru/aritmos/handlers/EventHandlerContextTest.java
@@ -30,7 +30,7 @@ class EventHandlerContextTest {
         Body(Branch branch) { this.b1 = branch; }
     }
 
-    @DisplayName("Обработчик BRANCH_PUBLIC преобразует тело события в карту")
+    @DisplayName("Обработчик BRANCH_PUBLIC преобразует тело события в словарь")
     @Test
     void branchPublicHandlerConvertsBodyToMap() throws Exception {
         VisitService visitService = mock(VisitService.class);

--- a/src/test/unit/java/ru/aritmos/keycloack/service/EndSessionEndpointResolverReplacementTest.java
+++ b/src/test/unit/java/ru/aritmos/keycloack/service/EndSessionEndpointResolverReplacementTest.java
@@ -18,7 +18,7 @@ import org.mockito.Mockito;
 
 class EndSessionEndpointResolverReplacementTest {
 
-    @DisplayName("resolve возвращает конечную точку Okta")
+    @DisplayName("Метод `resolve` возвращает конечную точку Okta")
     @Test
     void resolveReturnsOktaEndpoint() {
         BeanContext beanContext = Mockito.mock(BeanContext.class);

--- a/src/test/unit/java/ru/aritmos/keycloack/service/KeyCloackClientCoverageTest.java
+++ b/src/test/unit/java/ru/aritmos/keycloack/service/KeyCloackClientCoverageTest.java
@@ -35,7 +35,7 @@ class KeyCloackClientCoverageTest {
 
     private static final Logger log = LoggerFactory.getLogger(KeyCloackClientCoverageTest.class);
 
-    @DisplayName("getUserSessionByLogin возвращает сессию с максимальным временем старта")
+    @DisplayName("Получение сессии по логину возвращает запись с максимальным временем старта")
     @Test
     void getUserSessionByLoginReturnsSessionWithMaxStartTime() {
         log.info("Готовим клиента Keycloak и пользователя для получения сессии");
@@ -85,7 +85,7 @@ class KeyCloackClientCoverageTest {
                 result.get().getUserToken().getUser().getName());
     }
 
-    @DisplayName("getUserSessionByLogin возвращает пустой результат при некорректных данных пользователя")
+    @DisplayName("Получение сессии по логину возвращает пусто при некорректных данных пользователя")
     @Test
     void getUserSessionByLoginReturnsEmptyWhenUserDataInvalid() {
         log.info("Готовим клиента Keycloak и пользователя с некорректными данными");
@@ -115,7 +115,7 @@ class KeyCloackClientCoverageTest {
         assertTrue(result.isEmpty(), "Результат должен быть пустым");
     }
 
-    @DisplayName("isUserModuleTypeByUserName распознаёт тип модуля по составной роли")
+    @DisplayName("Проверка типа модуля по имени пользователя распознаёт составную роль")
     @Test
     void isUserModuleTypeByUserNameDetectsCompositeRoleType() {
         log.info("Готовим структуру ролей для проверки типа модуля пользователя");
@@ -159,7 +159,7 @@ class KeyCloackClientCoverageTest {
         assertTrue(result, "Ожидаем, что пользователь принадлежит типу admin");
     }
 
-    @DisplayName("getUserBySid возвращает пользователя при существующей сессии")
+    @DisplayName("Получение пользователя по `SID` возвращает данные при активной сессии")
     @Test
     void getUserBySidReturnsUserWhenSessionExists() {
         log.info("Готовим клиентов и сессии Keycloak для поиска пользователя по sid");
@@ -198,7 +198,7 @@ class KeyCloackClientCoverageTest {
         assertSame(user, result.get());
     }
 
-    @DisplayName("userLogout публикует события и обновляет параметры сессии")
+    @DisplayName("Выход пользователя публикует события и обновляет параметры сессии")
     @Test
     void userLogoutSendsEventsAndUpdatesSessionParams() {
         log.info("Готовим KeyCloackClient для сценария выхода пользователя");
@@ -255,7 +255,7 @@ class KeyCloackClientCoverageTest {
         verify(userResource).logout();
     }
 
-    @DisplayName("getAllBranchesByRegionName возвращает отделения из вложенных групп")
+    @DisplayName("Загрузка отделений по названию региона возвращает данные из вложенных групп")
     @Test
     void getAllBranchesByRegionNameReturnsRecursiveBranches() {
         log.info("Готовим KeyCloackClient и структуру регионов для поиска отделений");
@@ -285,7 +285,7 @@ class KeyCloackClientCoverageTest {
         verify(client).getAllBranchesByRegionId("region-1", keycloak);
     }
 
-    @DisplayName("getAllBranchesByRegionName выбрасывает исключение при отсутствии региона")
+    @DisplayName("Загрузка отделений по названию региона выбрасывает исключение при отсутствии группы")
     @Test
     void getAllBranchesByRegionNameThrowsWhenRegionMissing() {
         log.info("Готовим KeyCloackClient и список регионов без совпадений");

--- a/src/test/unit/java/ru/aritmos/keycloack/service/KeyCloackClientTest.java
+++ b/src/test/unit/java/ru/aritmos/keycloack/service/KeyCloackClientTest.java
@@ -17,7 +17,7 @@ import org.keycloak.representations.idm.UserRepresentation;
  */
 class KeyCloackClientTest {
 
-    @DisplayName("getBranchPathByBranchPrefix возвращает путь найденного отделения")
+    @DisplayName("Поиск пути отделения по префиксу возвращает найденный путь")
     @Test
     void getBranchPathByBranchPrefixReturnsPath() {
         KeyCloackClient client = spy(new KeyCloackClient());
@@ -33,7 +33,7 @@ class KeyCloackClientTest {
         assertEquals("/r/b", path);
     }
 
-    @DisplayName("getBranchPathByBranchPrefix возвращает null при отсутствии отделения")
+    @DisplayName("Поиск пути отделения по префиксу возвращает пустое значение при отсутствии отделения")
     @Test
     void getBranchPathByBranchPrefixReturnsNullWhenNotFound() {
         KeyCloackClient client = spy(new KeyCloackClient());
@@ -43,7 +43,7 @@ class KeyCloackClientTest {
         assertNull(client.getBranchPathByBranchPrefix("region", "PR"));
     }
 
-    @DisplayName("getAllBranchesByRegionId собирает отделения рекурсивно")
+    @DisplayName("Загрузка отделений по региону собирает структуру рекурсивно")
     @Test
     void getAllBranchesByRegionIdCollectsBranchesRecursively() {
         KeyCloackClient client = new KeyCloackClient();
@@ -77,7 +77,7 @@ class KeyCloackClientTest {
         assertTrue(result.contains(nestedBranch));
     }
 
-    @DisplayName("getKeycloak возвращает существующий экземпляр")
+    @DisplayName("Запрос экземпляра клиента Keycloak возвращает текущий объект")
     @Test
     void getKeycloakReturnsExistingInstance() {
         KeyCloackClient client = new KeyCloackClient();
@@ -89,7 +89,7 @@ class KeyCloackClientTest {
         assertSame(existing, result);
     }
 
-    @DisplayName("getUserInfo возвращает пользователя при наличии результата")
+    @DisplayName("Запрос сведений о пользователе возвращает данные при наличии результата")
     @Test
     void getUserInfoReturnsUserWhenFound() {
         KeyCloackClient client = new KeyCloackClient();
@@ -110,7 +110,7 @@ class KeyCloackClientTest {
         assertSame(user, result.get());
     }
 
-    @DisplayName("getUserInfo возвращает пустой Optional при отсутствии пользователя")
+    @DisplayName("Запрос сведений о пользователе возвращает пустой результат при отсутствии данных")
     @Test
     void getUserInfoReturnsEmptyWhenUserMissing() {
         KeyCloackClient client = new KeyCloackClient();

--- a/src/test/unit/java/ru/aritmos/model/BasedServiceTest.java
+++ b/src/test/unit/java/ru/aritmos/model/BasedServiceTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 
 class BasedServiceTest {
 
-    @DisplayName("Метод clone создаёт независимую копию исхода")
+    @DisplayName("Метод `clone` создаёт независимую копию исхода")
     @Test
     void cloneShouldCloneOutcomeIndependently() {
         Outcome outcome = new Outcome("1", "name");

--- a/src/test/unit/java/ru/aritmos/model/BranchConfigurationOperationsTest.java
+++ b/src/test/unit/java/ru/aritmos/model/BranchConfigurationOperationsTest.java
@@ -30,7 +30,7 @@ import ru.aritmos.test.TestLoggingExtension;
 @ExtendWith(TestLoggingExtension.class)
 class BranchConfigurationOperationsTest {
 
-    @DisplayName("Update Visit With Custom Action Places Entities And Sends Events")
+    @DisplayName("Обновление визита с произвольным действием размещает сущности и отправляет события")
     @Test
     void updateVisitWithCustomActionPlacesEntitiesAndSendsEvents() {
         log.info("Формируем отделение с очередью, пулом точек и сотрудниками");
@@ -99,7 +99,7 @@ class BranchConfigurationOperationsTest {
         assertEquals(visit.getId(), ((Visit) events.get(0).getBody()).getId());
     }
 
-    @DisplayName("Update Visit With Custom Action Throws When Point Busy")
+    @DisplayName("Обновление визита с произвольным действием завершится ошибкой при занятой точке")
     @Test
     void updateVisitWithCustomActionThrowsWhenPointBusy() {
         log.info("Готовим отделение с занятой точкой обслуживания");
@@ -131,7 +131,7 @@ class BranchConfigurationOperationsTest {
         assertEquals(HttpStatus.CONFLICT, exception.getStatus());
     }
 
-    @DisplayName("Add Update Service Point Restores State And Publishes Events")
+    @DisplayName("Обновление точек обслуживания восстанавливает состояние и публикует события")
     @Test
     void addUpdateServicePointRestoresStateAndPublishesEvents() {
         log.info("Настраиваем отделение с существующей точкой и назначенным визитом");
@@ -165,7 +165,7 @@ class BranchConfigurationOperationsTest {
         verify(eventService).sendChangedEvent(eq("config"), eq(false), isNull(), eq(newcomer), anyMap(), eq("Add service point"));
     }
 
-    @DisplayName("Add Update Queues Restores Visits And Notifies Consumers")
+    @DisplayName("Обновление очередей сохраняет визиты и уведомляет потребителей")
     @Test
     void addUpdateQueuesRestoresVisitsAndNotifiesConsumers() {
         log.info("Готовим отделение с очередями и точкой обслуживания");

--- a/src/test/unit/java/ru/aritmos/model/BranchEntityTest.java
+++ b/src/test/unit/java/ru/aritmos/model/BranchEntityTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 
 class BranchEntityTest {
 
-    @DisplayName("Метод clone копирует базовые поля")
+    @DisplayName("Метод `clone` копирует базовые поля")
     @Test
     void cloneShouldCopyBasicFields() {
         BranchEntity entity = new BranchEntity("id", "name");

--- a/src/test/unit/java/ru/aritmos/model/BranchTest.java
+++ b/src/test/unit/java/ru/aritmos/model/BranchTest.java
@@ -28,7 +28,7 @@ import ru.aritmos.service.VisitService;
  */
 class BranchTest {
 
-    @DisplayName("incrementTicketCounter возвращает новое значение счётчика")
+    @DisplayName("Счётчик талонов увеличивается и возвращает новое значение")
     @Test
     void incrementTicketCounterReturnsNewValue() {
         Branch branch = new Branch("b1", "Branch");
@@ -41,7 +41,7 @@ class BranchTest {
         assertEquals(1, queue.getTicketCounter());
     }
 
-    @DisplayName("incrementTicketCounter возвращает -1 для чужой очереди")
+    @DisplayName("Счётчик талонов возвращает -1 для чужой очереди")
     @Test
     void incrementTicketCounterReturnsMinusOneForForeignQueue() {
         Branch branch = new Branch("b1", "Branch");
@@ -52,7 +52,7 @@ class BranchTest {
         assertEquals(-1, result);
     }
 
-    @DisplayName("getAllVisits собирает визиты из пользователей, точек и очередей")
+    @DisplayName("Сводный набор визитов собирает данные пользователей, точек и очередей")
     @Test
     void getAllVisitsCollectsFromUsersServicePointsAndQueues() {
         Branch branch = new Branch("b1", "Branch");
@@ -93,7 +93,7 @@ class BranchTest {
         assertTrue(all.containsKey("v4"));
     }
 
-    @DisplayName("getAllVisitsList возвращает визиты из пользователей, точек и очередей")
+    @DisplayName("Плоский список визитов возвращает данные из пользователей, точек и очередей")
     @Test
     void getAllVisitsListCollectsFromUsersServicePointsAndQueues() {
         Branch branch = new Branch("b1", "Branch");
@@ -134,7 +134,7 @@ class BranchTest {
         assertTrue(all.stream().anyMatch(v -> v.getId().equals("v4")));
     }
 
-    @DisplayName("getVisitsByStatus фильтрует визиты по статусу")
+    @DisplayName("Фильтрация по статусу оставляет только подходящие визиты")
     @Test
     void getVisitsByStatusFiltersVisits() {
         Branch branch = new Branch("b1", "Branch");
@@ -151,7 +151,7 @@ class BranchTest {
         assertFalse(filtered.containsKey("v2"));
     }
 
-    @DisplayName("getVisitsByStatus возвращает пустой результат при отсутствии подходящих статусов")
+    @DisplayName("Фильтрация по статусу даёт пустой результат без подходящих визитов")
     @Test
     void getVisitsByStatusReturnsEmptyForMissingStatuses() {
         Branch branch = new Branch("b1", "Branch");
@@ -165,7 +165,7 @@ class BranchTest {
         assertTrue(filtered.isEmpty());
     }
 
-    @DisplayName("getVisitsByStatus собирает визиты со статусом из всех источников")
+    @DisplayName("Фильтрация по статусу учитывает все источники визитов")
     @Test
     void getVisitsByStatusCollectsFromUsersServicePointsAndQueues() {
         // Формируем отделение с визитами из разных источников
@@ -211,7 +211,7 @@ class BranchTest {
         assertFalse(filtered.containsKey("v5"));
     }
 
-    @DisplayName("incrementTicketCounter увеличивает счётчик последовательно")
+    @DisplayName("Счётчик талонов увеличивается последовательно без пропусков")
     @Test
 
     void incrementTicketCounterIncrementsSequentially() {
@@ -227,7 +227,7 @@ class BranchTest {
         assertEquals(2, queue.getTicketCounter());
     }
 
-    @DisplayName("getAllVisitsList содержит дубликаты одного визита")
+    @DisplayName("Плоский список визитов содержит дубликаты при повторном добавлении")
     @Test
 
     void getAllVisitsListContainsDuplicatesForSameVisit() {
@@ -251,7 +251,7 @@ class BranchTest {
         assertSame(visitList.get(0), visitList.get(1), "Оба элемента списка указывают на один объект");
     }
 
-    @DisplayName("getAllVisits возвращает пустую карту при отсутствии сущностей")
+    @DisplayName("Карточное представление визитов пусто при отсутствии сущностей")
     @Test
     void getAllVisitsReturnsEmptyWhenNoEntities() {
         Branch branch = new Branch("b1", "Branch");
@@ -261,7 +261,7 @@ class BranchTest {
         assertTrue(visits.isEmpty());
     }
 
-    @DisplayName("getAllVisitsList возвращает пустой список при отсутствии сущностей")
+    @DisplayName("Плоский список визитов пуст при отсутствии сущностей")
     @Test
     void getAllVisitsListReturnsEmptyWhenNoEntities() {
         Branch branch = new Branch("b1", "Branch");
@@ -272,7 +272,7 @@ class BranchTest {
     }
 
 
-    @DisplayName("openServicePoint назначает пользователя и публикует события")
+    @DisplayName("Открытие точки назначения закрепляет пользователя и публикует события")
     @Test
     void openServicePointAssignsUserAndPublishesEvents() throws IOException {
         // Готовим отделение с точкой обслуживания без пользователя
@@ -308,7 +308,7 @@ class BranchTest {
         assertSame(sp, captor.getValue().getBody());
     }
 
-    @DisplayName("openServicePoint выбрасывает исключение при занятой точке")
+    @DisplayName("Открытие точки завершается ошибкой при занятом рабочем месте")
     @Test
     void openServicePointThrowsIfBusy() {
         // Точка обслуживания уже занята другим пользователем
@@ -338,7 +338,7 @@ class BranchTest {
     }
 
 
-    @DisplayName("openServicePoint добавляет пользователя без указания точки")
+    @DisplayName("Открытие точки добавляет пользователя даже без явного указания точки")
     @Test
     void openServicePointAddsUserWithoutServicePoint() throws IOException {
         // Пользователь не указал точку обслуживания
@@ -359,7 +359,7 @@ class BranchTest {
         verifyNoInteractions(eventService);
     }
 
-    @DisplayName("openServicePoint выбрасывает исключение при отсутствии точки")
+    @DisplayName("Открытие точки завершается ошибкой при отсутствии точки в отделении")
     @Test
     void openServicePointThrowsIfServicePointNotFound() {
         // Пользователь пытается открыть отсутствующую точку
@@ -381,7 +381,7 @@ class BranchTest {
         assertSame(user, branch.getUsers().get("u1"));
     }
 
-    @DisplayName("closeServicePoint публикует события и завершает визит")
+    @DisplayName("Закрытие точки публикует события и завершает визит")
     @Test
     void closeServicePointSendsEventsAndEndsVisit() {
         Branch branch = spy(new Branch("b1", "B1"));
@@ -424,7 +424,7 @@ class BranchTest {
         assertTrue(types.contains("SERVICE_POINT_CLOSED"));
     }
 
-    @DisplayName("closeServicePoint выбрасывает исключение при отсутствии точки")
+    @DisplayName("Закрытие точки завершается ошибкой при отсутствии точки в отделении")
     @Test
     void closeServicePointThrowsWhenPointMissing() {
         // В отделении нет точки обслуживания с указанным идентификатором
@@ -452,7 +452,7 @@ class BranchTest {
         verifyNoInteractions(visitService);
     }
 
-    @DisplayName("closeServicePoint выбрасывает исключение при уже закрытой точке")
+    @DisplayName("Закрытие точки завершается ошибкой при повторном вызове")
     @Test
     void closeServicePointThrowsWhenAlreadyClosed() {
         // Точка обслуживания существует, но на ней уже нет сотрудника
@@ -485,7 +485,7 @@ class BranchTest {
         verify(visitService, times(1)).getServicePointHashMap("b1");
     }
 
-    @DisplayName("addUpdateService обновляет визиты при включённой проверке")
+    @DisplayName("Обновление услуг актуализирует визиты при включённой проверке")
     @Test
     void addUpdateServiceRefreshesVisitsWhenCheckEnabled() {
         // Обновляем услугу, которая используется в активном визите
@@ -536,7 +536,7 @@ class BranchTest {
                         eq("Update service"));
     }
 
-    @DisplayName("addUpdateService выбрасывает ошибку при отключённой проверке и используемой услуге")
+    @DisplayName("Обновление услуг завершает выполнение ошибкой при запрете проверки и используемой услуге")
     @Test
     void addUpdateServiceFailsWhenCheckDisabledAndServiceInUse() {
         // При отключённой проверке визитов обновление должно быть запрещено
@@ -577,7 +577,7 @@ class BranchTest {
         assertSame(existing, branch.getServices().get("s1"));
     }
 
-    @DisplayName("deleteServices очищает ссылки на услуги в визитах")
+    @DisplayName("Удаление услуг очищает ссылки на услуги в визитах")
     @Test
     void deleteServicesCleansVisitReferences() {
         // Удаляем услугу и проверяем обновление всех связей визита
@@ -622,7 +622,7 @@ class BranchTest {
     }
 
 
-    @DisplayName("updateVisit размещает сущности и отправляет события")
+    @DisplayName("Обновление визита размещает сущности и инициирует события")
     @Test
     void updateVisitPlacesEntitiesAndSendsEvents() {
         // Готовим отделение с очередью и пулом визитов
@@ -698,7 +698,7 @@ class BranchTest {
                 .send(eq("frontend"), eq(false), argThat(event -> "VISIT_CALLED".equals(event.getEventType())));
     }
 
-    @DisplayName("updateVisit заменяет текущий визит точки обслуживания")
+    @DisplayName("Обновление визита заменяет текущую запись точки обслуживания")
     @Test
     void updateVisitReplacesExistingServicePointVisit() {
         // На точке обслуживания уже был другой визит и пользователь
@@ -740,7 +740,7 @@ class BranchTest {
         verify(eventService).send(eq("*"), eq(false), any(Event.class));
     }
 
-    @DisplayName("updateVisit выбрасывает исключение при выходе индекса очереди за пределы")
+    @DisplayName("Обновление визита сообщает об ошибке при выходе индекса очереди за пределы")
     @Test
     void updateVisitFailsWhenQueueIndexOutOfRange() {
         // Индекс вставки выходит за пределы очереди

--- a/src/test/unit/java/ru/aritmos/model/BranchUpdateVisitOverloadsTest.java
+++ b/src/test/unit/java/ru/aritmos/model/BranchUpdateVisitOverloadsTest.java
@@ -29,7 +29,7 @@ class BranchUpdateVisitOverloadsTest {
 
     private static final Logger log = LoggerFactory.getLogger(BranchUpdateVisitOverloadsTest.class);
 
-    @DisplayName("Update Visit With Boolean Places Visit At Start")
+    @DisplayName("Обновление визита с флагом размещает запись в начале очереди")
     @Test
     void updateVisitWithBooleanPlacesVisitAtStart() {
         VisitEvent.TRANSFER_TO_SERVICE_POINT_POOL.getParameters().clear();
@@ -101,7 +101,7 @@ class BranchUpdateVisitOverloadsTest {
                 argThat(evt -> "VISIT_TRANSFER_TO_SERVICE_POINT_POOL".equals(evt.getEventType())));
     }
 
-    @DisplayName("Update Visit With Boolean Places Visit At End")
+    @DisplayName("Обновление визита с флагом помещает запись в конец очереди")
     @Test
     void updateVisitWithBooleanPlacesVisitAtEnd() {
         VisitEvent.TRANSFER_TO_SERVICE_POINT_POOL.getParameters().clear();
@@ -163,7 +163,7 @@ class BranchUpdateVisitOverloadsTest {
         verify(eventService).send(eq("frontend"), eq(false), any(Event.class));
     }
 
-    @DisplayName("Update Visit Without Boolean Places Visit At Start By Default")
+    @DisplayName("Обновление визита без флага по умолчанию ставит запись в начало")
     @Test
     void updateVisitWithoutBooleanPlacesVisitAtStartByDefault() {
         VisitEvent.TRANSFER_TO_SERVICE_POINT_POOL.getParameters().clear();

--- a/src/test/unit/java/ru/aritmos/model/DeliveredServiceTest.java
+++ b/src/test/unit/java/ru/aritmos/model/DeliveredServiceTest.java
@@ -5,7 +5,7 @@ import static ru.aritmos.test.LoggingAssertions.*;
 import org.junit.jupiter.api.DisplayName;
 
 class DeliveredServiceTest {
-    @DisplayName("Clone Creates Independent Copy")
+    @DisplayName("Метод `clone` возвращает независимую копию")
     @Test
     void cloneCreatesIndependentCopy() {
         Outcome outcome = new Outcome("o1", "outcome");

--- a/src/test/unit/java/ru/aritmos/model/EntityTest.java
+++ b/src/test/unit/java/ru/aritmos/model/EntityTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 class EntityTest {
 
     @Test
-    @DisplayName("билдер создает сущность с указанными значениями")
+    @DisplayName("Построитель создаёт сущность с указанными значениями")
     void builderCreatesEntity() {
         Entity entity = Entity.builder()
                 .id("123")

--- a/src/test/unit/java/ru/aritmos/model/EntryPointTest.java
+++ b/src/test/unit/java/ru/aritmos/model/EntryPointTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 
 class EntryPointTest {
 
-    @DisplayName("Наследует поля BranchEntity")
+    @DisplayName("Модель EntryPoint наследует поля BranchEntity")
     @Test
     void shouldInheritBranchEntityFields() {
         EntryPoint entryPoint = new EntryPoint();

--- a/src/test/unit/java/ru/aritmos/model/GroovyScriptTest.java
+++ b/src/test/unit/java/ru/aritmos/model/GroovyScriptTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test;
 class GroovyScriptTest {
 
     @Test
-    @DisplayName("по умолчанию билдер создает пустые изменяемые карты входных и выходных параметров")
+    @DisplayName("По умолчанию построитель создаёт пустые изменяемые карты входных и выходных параметров")
     void builderCreatesEmptyMapsByDefault() {
         GroovyScript script = GroovyScript.builder().build();
 
@@ -30,7 +30,7 @@ class GroovyScriptTest {
     }
 
     @Test
-    @DisplayName("билдер позволяет задать код правила и собственные параметры")
+    @DisplayName("Построитель позволяет задать код правила и собственные параметры")
     void builderSupportsPopulatingData() {
         HashMap<Object, Object> output = new HashMap<>();
         output.put("result", "готово");
@@ -47,7 +47,7 @@ class GroovyScriptTest {
     }
 
     @Test
-    @DisplayName("модель GroovyScript помечена Serdeable и использует JsonInclude.ALWAYS для карт")
+    @DisplayName("Модель GroovyScript помечена аннотацией Serdeable и использует режим JsonInclude.ALWAYS для карт")
     void verifiesAnnotations() throws NoSuchFieldException {
         assertTrue(GroovyScript.class.isAnnotationPresent(Serdeable.class));
 

--- a/src/test/unit/java/ru/aritmos/model/OutcomeTest.java
+++ b/src/test/unit/java/ru/aritmos/model/OutcomeTest.java
@@ -5,7 +5,7 @@ import static ru.aritmos.test.LoggingAssertions.*;
 import org.junit.jupiter.api.DisplayName;
 
 class OutcomeTest {
-    @DisplayName("Clone Creates Independent Copy")
+    @DisplayName("Метод `clone` возвращает независимую копию исхода")
     @Test
     void cloneCreatesIndependentCopy() {
         Outcome original = new Outcome("1", "name");

--- a/src/test/unit/java/ru/aritmos/model/QueueTest.java
+++ b/src/test/unit/java/ru/aritmos/model/QueueTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test;
  */
 class QueueTest {
 
-    @DisplayName("Constructor Generates Id And Sets Fields")
+    @DisplayName("Конструктор без идентификатора создаёт уникальный идентификатор и заполняет поля")
     @Test
     void constructorGeneratesIdAndSetsFields() {
         Queue queue = new Queue("Main", "A", 60);
@@ -21,7 +21,7 @@ class QueueTest {
         assertEquals(0, queue.getTicketCounter());
     }
 
-    @DisplayName("Constructor With Explicit Id Sets All Fields")
+    @DisplayName("Конструктор с явным идентификатором заполняет все поля")
     @Test
     void constructorWithExplicitIdSetsAllFields() {
         Queue queue = new Queue("q1", "Secondary", "B", 30);

--- a/src/test/unit/java/ru/aritmos/model/RealmAccessTest.java
+++ b/src/test/unit/java/ru/aritmos/model/RealmAccessTest.java
@@ -10,7 +10,7 @@ import org.keycloak.representations.idm.GroupRepresentation;
 
 class RealmAccessTest {
 
-    @DisplayName("Builder And Setters Construct Full Access")
+    @DisplayName("Строитель и сеттеры формируют полный доступ")
     @Test
     void builderAndSettersConstructFullAccess() {
         GroupRepresentation branch = new GroupRepresentation();

--- a/src/test/unit/java/ru/aritmos/model/SegmentationRuleDataTest.java
+++ b/src/test/unit/java/ru/aritmos/model/SegmentationRuleDataTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 
 class SegmentationRuleDataTest {
 
-    @DisplayName("Builder Should Populate All Fields")
+    @DisplayName("Строитель заполняет все поля объекта")
     @Test
     void builderShouldPopulateAllFields() {
         HashMap<String, String> visitProperty = new HashMap<>();
@@ -32,7 +32,7 @@ class SegmentationRuleDataTest {
         assertEquals("queue11", data.getQueueId());
     }
 
-    @DisplayName("Visit Property Can Be Assigned Later")
+    @DisplayName("Свойства визита допускают позднее присвоение")
     @Test
     void visitPropertyCanBeAssignedLater() {
         SegmentationRuleData data = SegmentationRuleData.builder().id("rule2").build();

--- a/src/test/unit/java/ru/aritmos/model/ServiceGroupTest.java
+++ b/src/test/unit/java/ru/aritmos/model/ServiceGroupTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 
 class ServiceGroupTest {
 
-    @DisplayName("Custom Constructor Should Fill Hierarchy Fields")
+    @DisplayName("Пользовательский конструктор заполняет поля иерархии")
     @Test
     void customConstructorShouldFillHierarchyFields() {
         List<String> services = List.of("s1", "s2");
@@ -21,7 +21,7 @@ class ServiceGroupTest {
         assertEquals(services, group.getServiceIds());
     }
 
-    @DisplayName("Segmentation Identifiers Should Be Mutable")
+    @DisplayName("Идентификаторы сегментации допускают изменение")
     @Test
     void segmentationIdentifiersShouldBeMutable() {
         ServiceGroup group = new ServiceGroup();

--- a/src/test/unit/java/ru/aritmos/model/ServiceTest.java
+++ b/src/test/unit/java/ru/aritmos/model/ServiceTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 
 class ServiceTest {
 
-    @DisplayName("Clone Should Copy Fields And Maps Independently")
+    @DisplayName("Метод `clone` копирует поля и карты независимо")
     @Test
     void cloneShouldCopyFieldsAndMapsIndependently() {
         Outcome outcome = new Outcome("1", "outcome");

--- a/src/test/unit/java/ru/aritmos/model/TokenTest.java
+++ b/src/test/unit/java/ru/aritmos/model/TokenTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 
 class TokenTest {
 
-    @DisplayName("Builder And Setters Transfer Token Data")
+    @DisplayName("Строитель и сеттеры переносят данные токена")
     @Test
     void builderAndSettersTransferTokenData() {
         Token viaBuilder = Token.builder()

--- a/src/test/unit/java/ru/aritmos/model/UserInfoTest.java
+++ b/src/test/unit/java/ru/aritmos/model/UserInfoTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 
 class UserInfoTest {
 
-    @DisplayName("Builder And Setters Behave The Same")
+    @DisplayName("Построитель и сеттеры формируют одинаковый результат")
     @Test
     void builderAndSettersBehaveTheSame() {
         RealmAccess access = RealmAccess.builder()

--- a/src/test/unit/java/ru/aritmos/model/UserSessionTest.java
+++ b/src/test/unit/java/ru/aritmos/model/UserSessionTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 
 class UserSessionTest {
 
-    @DisplayName("Builder Should Provide Empty Params By Default")
+    @DisplayName("Строитель по умолчанию создаёт пустые параметры")
     @Test
     void builderShouldProvideEmptyParamsByDefault() {
         UserSession session = UserSession.builder().login("ivan").build();
@@ -18,7 +18,7 @@ class UserSessionTest {
         assertTrue(session.getParams().isEmpty());
     }
 
-    @DisplayName("Setters Should Update Mutable Fields")
+    @DisplayName("Сеттеры обновляют изменяемые поля")
     @Test
     void settersShouldUpdateMutableFields() {
         UserSession session = new UserSession();

--- a/src/test/unit/java/ru/aritmos/model/UserTest.java
+++ b/src/test/unit/java/ru/aritmos/model/UserTest.java
@@ -11,7 +11,7 @@ import org.keycloak.representations.idm.GroupRepresentation;
 import ru.aritmos.keycloack.service.KeyCloackClient;
 
 class UserTest {
-    @DisplayName("Constructor Initializes Fields With Keycloak Client")
+    @DisplayName("Конструктор заполняет поля при переданном клиенте Keycloak")
     @Test
     void constructorInitializesFieldsWithKeycloakClient() {
         KeyCloackClient client = mock(KeyCloackClient.class);
@@ -27,7 +27,7 @@ class UserTest {
         assertSame(client, user.getKeyCloackClient());
     }
 
-    @DisplayName("Break Status And Duration Calculation")
+    @DisplayName("Статус перерыва корректно влияет на расчёт длительности")
     @Test
     void breakStatusAndDurationCalculation() {
         User user = new User("2", "worker", null);
@@ -43,7 +43,7 @@ class UserTest {
         assertEquals(45L, user.getLastBreakDuration());
     }
 
-    @DisplayName("Constructor Generates Id When Not Provided")
+    @DisplayName("Конструктор генерирует идентификатор при его отсутствии")
     @Test
     void constructorGeneratesIdWhenNotProvided() {
         KeyCloackClient client = mock(KeyCloackClient.class);

--- a/src/test/unit/java/ru/aritmos/model/UserTokenTest.java
+++ b/src/test/unit/java/ru/aritmos/model/UserTokenTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 
 class UserTokenTest {
 
-    @DisplayName("Builder и сеттеры создают токен пользователя")
+    @DisplayName("Построитель и сеттеры создают токен пользователя")
     @Test
     void builderAndSettersCreateUserToken() {
         UserInfo info = UserInfo.builder()

--- a/src/test/unit/java/ru/aritmos/model/keycloak/ClientAccessTest.java
+++ b/src/test/unit/java/ru/aritmos/model/keycloak/ClientAccessTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 
 class ClientAccessTest {
 
-    @DisplayName("Builder And Setters Produce Same Result")
+    @DisplayName("Строитель и сеттеры дают одинаковый результат")
     @Test
     void builderAndSettersProduceSameResult() {
         ClientAccess viaBuilder = ClientAccess.builder()

--- a/src/test/unit/java/ru/aritmos/model/keycloak/ModuleRoleTest.java
+++ b/src/test/unit/java/ru/aritmos/model/keycloak/ModuleRoleTest.java
@@ -7,7 +7,7 @@ import static ru.aritmos.test.LoggingAssertions.*;
 
 class ModuleRoleTest {
 
-    @DisplayName("Method Chains Produce Correct Object")
+    @DisplayName("Цепочки методов формируют корректный объект")
     @Test
     void methodChainsProduceCorrectObject() {
         ModuleRole direct = new ModuleRole()

--- a/src/test/unit/java/ru/aritmos/model/keycloak/RealmAccessTest.java
+++ b/src/test/unit/java/ru/aritmos/model/keycloak/RealmAccessTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 
 class RealmAccessTest {
 
-    @DisplayName("Builder And Setters Form Role List")
+    @DisplayName("Построитель и сеттеры формируют список ролей")
     @Test
     void builderAndSettersFormRoleList() {
         RealmAccess viaBuilder = RealmAccess.builder()

--- a/src/test/unit/java/ru/aritmos/model/keycloak/TokenTest.java
+++ b/src/test/unit/java/ru/aritmos/model/keycloak/TokenTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 
 class TokenTest {
 
-    @DisplayName("Builder и сеттеры заполняют поля токена")
+    @DisplayName("Построитель и сеттеры заполняют поля токена")
     @Test
     void builderAndSettersPopulateTokenFields() {
         Token viaBuilder = Token.builder()

--- a/src/test/unit/java/ru/aritmos/model/keycloak/UserInfoTest.java
+++ b/src/test/unit/java/ru/aritmos/model/keycloak/UserInfoTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 
 class UserInfoTest {
 
-    @DisplayName("Builder и сеттеры заполняют все поля")
+    @DisplayName("Построитель и сеттеры заполняют все поля")
     @Test
     void builderAndSettersSupportAllFields() {
         RealmAccess realmAccess = RealmAccess.builder()

--- a/src/test/unit/java/ru/aritmos/model/keycloak/UserSessionTest.java
+++ b/src/test/unit/java/ru/aritmos/model/keycloak/UserSessionTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 
 class UserSessionTest {
 
-    @DisplayName("Builder And Setters Create Complete Session")
+    @DisplayName("Построитель и сеттеры формируют полную сессию")
     @Test
     void builderAndSettersCreateCompleteSession() {
         UserToken token = UserToken.builder()

--- a/src/test/unit/java/ru/aritmos/model/keycloak/UserTokenTest.java
+++ b/src/test/unit/java/ru/aritmos/model/keycloak/UserTokenTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 
 class UserTokenTest {
 
-    @DisplayName("Builder And Setters Construct Object")
+    @DisplayName("Построитель и сеттеры формируют объект токена")
     @Test
     void builderAndSettersConstructObject() {
         UserInfo info = UserInfo.builder()

--- a/src/test/unit/java/ru/aritmos/model/tiny/TinyVisitTest.java
+++ b/src/test/unit/java/ru/aritmos/model/tiny/TinyVisitTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test;
 
 class TinyVisitTest {
 
-    @DisplayName("Calculates Waiting Time From Transfer Date")
+    @DisplayName("Ожидание рассчитывается от даты последнего перевода")
     @Test
     void calculatesWaitingTimeFromTransferDate() {
         ZonedDateTime now = ZonedDateTime.now();
@@ -25,7 +25,7 @@ class TinyVisitTest {
         assertTrue(Math.abs(actual - expected) <= 1, "waiting time should match");
     }
 
-    @DisplayName("Calculates Total Waiting Time From Create Date")
+    @DisplayName("Суммарное ожидание считается от даты создания визита")
     @Test
     void calculatesTotalWaitingTimeFromCreateDate() {
         ZonedDateTime now = ZonedDateTime.now();

--- a/src/test/unit/java/ru/aritmos/model/visit/TransactionCompletionStatusTest.java
+++ b/src/test/unit/java/ru/aritmos/model/visit/TransactionCompletionStatusTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 class TransactionCompletionStatusTest {
 
     @Test
-    @DisplayName("перечисление содержит полный список статусов транзакции")
+    @DisplayName("Перечисление содержит полный список статусов транзакции")
     void verifyFullSetOfStatuses() {
         TransactionCompletionStatus[] ожидаемыеСтатусы = {
             TransactionCompletionStatus.OK,
@@ -29,7 +29,7 @@ class TransactionCompletionStatusTest {
     }
 
     @Test
-    @DisplayName("можно получить статус по его строковому имени")
+    @DisplayName("Статус можно получить по его строковому имени")
     void retrievesStatusByName() {
         assertEquals(
             TransactionCompletionStatus.REMOVED_BY_EMP,
@@ -37,7 +37,7 @@ class TransactionCompletionStatusTest {
     }
 
     @Test
-    @DisplayName("перечисление помечено аннотацией Serdeable")
+    @DisplayName("Перечисление помечено аннотацией Serdeable")
     void verifySerdeableAnnotation() {
         assertTrue(TransactionCompletionStatus.class.isAnnotationPresent(Serdeable.class));
     }

--- a/src/test/unit/java/ru/aritmos/model/visit/VisitEventInformationTest.java
+++ b/src/test/unit/java/ru/aritmos/model/visit/VisitEventInformationTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 
 class VisitEventInformationTest {
 
-    @DisplayName("Builder Should Create Instance With All Fields")
+    @DisplayName("Строитель формирует экземпляр со всеми полями")
     @Test
     void builderShouldCreateInstanceWithAllFields() {
         ZonedDateTime now = ZonedDateTime.now();

--- a/src/test/unit/java/ru/aritmos/model/visit/VisitEventTest.java
+++ b/src/test/unit/java/ru/aritmos/model/visit/VisitEventTest.java
@@ -7,34 +7,34 @@ import org.junit.jupiter.api.Test;
 
 class VisitEventTest {
 
-    @DisplayName("Test Is New Of Transaction")
+    @DisplayName("Событие помечается как новое в рамках транзакции")
     @Test
     void testIsNewOfTransaction() {
         assertTrue(VisitEvent.isNewOfTransaction(VisitEvent.STOP_SERVING));
         assertFalse(VisitEvent.isNewOfTransaction(VisitEvent.CREATED));
     }
 
-    @DisplayName("Test Is Front End Event")
+    @DisplayName("Событие распознаётся как фронтовое")
     @Test
     void testIsFrontEndEvent() {
         assertTrue(VisitEvent.isFrontEndEvent(VisitEvent.CREATED));
         assertFalse(VisitEvent.isFrontEndEvent(VisitEvent.VISIT_END_TRANSACTION));
     }
 
-    @DisplayName("Test Is Ignored In Stat")
+    @DisplayName("Событие учитывает признак игнорирования в статистике")
     @Test
     void testIsIgnoredInStat() {
         assertFalse(VisitEvent.isIgnoredInStat(VisitEvent.CREATED));
     }
 
-    @DisplayName("Test Get Status")
+    @DisplayName("Метод `getStatus` возвращает корректный статус события")
     @Test
     void testGetStatus() {
         assertEquals(TransactionCompletionStatus.STOP_SERVING, VisitEvent.getStatus(VisitEvent.STOP_SERVING));
         assertNull(VisitEvent.getStatus(VisitEvent.CREATED));
     }
 
-    @DisplayName("Test Can Be Next")
+    @DisplayName("Метод `canBeNext` определяет допустимость следующего события")
     @Test
     void testCanBeNext() {
         VisitEvent current = VisitEvent.CREATED;
@@ -47,7 +47,7 @@ class VisitEventTest {
         assertFalse(current.canBeNext(nextForbidden));
     }
 
-    @DisplayName("Test Get State")
+    @DisplayName("Метод `getState` возвращает состояние события")
     @Test
     void testGetState() {
         assertEquals(VisitState.CREATED, VisitEvent.CREATED.getState());

--- a/src/test/unit/java/ru/aritmos/model/visit/VisitStateTest.java
+++ b/src/test/unit/java/ru/aritmos/model/visit/VisitStateTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 class VisitStateTest {
 
     @Test
-    @DisplayName("перечисление содержит последовательность состояний визита")
+    @DisplayName("Перечисление содержит последовательность состояний визита")
     void verifyListOfStates() {
         VisitState[] ожидаемыеСостояния = {
             VisitState.CREATED,
@@ -24,13 +24,13 @@ class VisitStateTest {
     }
 
     @Test
-    @DisplayName("можно получить состояние по его имени")
+    @DisplayName("Состояние можно получить по его имени")
     void retrievesStateByName() {
         assertEquals(VisitState.WAITING_IN_QUEUE, VisitState.valueOf("WAITING_IN_QUEUE"));
     }
 
     @Test
-    @DisplayName("перечисление VisitState также аннотировано Serdeable")
+    @DisplayName("Перечисление `VisitState` также аннотировано Serdeable")
     void verifySerdeableAnnotation() {
         assertTrue(VisitState.class.isAnnotationPresent(Serdeable.class));
     }

--- a/src/test/unit/java/ru/aritmos/model/visit/VisitTest.java
+++ b/src/test/unit/java/ru/aritmos/model/visit/VisitTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 
 class VisitTest {
 
-    @DisplayName("Get Waiting Time Calculates Difference")
+    @DisplayName("Метод `getWaitingTime` рассчитывает продолжительность ожидания")
     @Test
     void getWaitingTimeCalculatesDifference() {
         ZonedDateTime start = ZonedDateTime.now();
@@ -22,7 +22,7 @@ class VisitTest {
         assertEquals(10L, visit.getWaitingTime());
     }
 
-    @DisplayName("Get Returning Time Uses Return Date Time")
+    @DisplayName("Метод `getReturningTime` использует время возврата")
     @Test
     void getReturningTimeUsesReturnDateTime() {
         ZonedDateTime returnTime = ZonedDateTime.now().minusSeconds(5);
@@ -32,14 +32,14 @@ class VisitTest {
         assertTrue(Math.abs(actual - expected) <= 1);
     }
 
-    @DisplayName("Get Returning Time Returns Zero When Null")
+    @DisplayName("Метод `getReturningTime` возвращает ноль при отсутствии времени возврата")
     @Test
     void getReturningTimeReturnsZeroWhenNull() {
         Visit visit = Visit.builder().build();
         assertEquals(0L, visit.getReturningTime());
     }
 
-    @DisplayName("Get Transfering Time Uses Transfer Date Time")
+    @DisplayName("Метод `getTransferingTime` использует время перевода")
     @Test
     void getTransferingTimeUsesTransferDateTime() {
         ZonedDateTime transferTime = ZonedDateTime.now().minusSeconds(7);
@@ -49,7 +49,7 @@ class VisitTest {
         assertTrue(Math.abs(actual - expected) <= 1);
     }
 
-    @DisplayName("Get Visit Life Time Calculates Difference")
+    @DisplayName("Метод `getVisitLifeTime` рассчитывает длительность визита")
     @Test
     void getVisitLifeTimeCalculatesDifference() {
         ZonedDateTime start = ZonedDateTime.now();
@@ -61,7 +61,7 @@ class VisitTest {
         assertEquals(20L, visit.getVisitLifeTime());
     }
 
-    @DisplayName("Get Serving Time Calculates Difference")
+    @DisplayName("Метод `getServingTime` рассчитывает время обслуживания")
     @Test
     void getServingTimeCalculatesDifference() {
         ZonedDateTime start = ZonedDateTime.now();

--- a/src/test/unit/java/ru/aritmos/service/VisitServiceCreateVirtualVisit2Test.java
+++ b/src/test/unit/java/ru/aritmos/service/VisitServiceCreateVirtualVisit2Test.java
@@ -52,7 +52,7 @@ class VisitServiceCreateVirtualVisit2Test {
         }
     }
 
-    @DisplayName("Создание VirtualVisit2 формирует визит и запускает обслуживание с сотрудником точки")
+    @DisplayName("Создание виртуального визита формирует запись и запускает обслуживание с сотрудником точки")
     @Test
     void createVirtualVisit2CreatesVisitAndStartsServingWithServicePointStaff() throws SystemException {
         Branch branch = new Branch("b1", "Отделение №1");
@@ -140,7 +140,7 @@ class VisitServiceCreateVirtualVisit2Test {
         assertEquals(staff.getName(), startServing.getParameters().get("staffName"));
     }
 
-    @DisplayName("Создание VirtualVisit2 использует данные Keycloak при отсутствии пользователя у точки")
+    @DisplayName("Метод `createVirtualVisit2` использует данные Keycloak при отсутствии пользователя у точки")
     @Test
     void createVirtualVisit2UsesKeycloakDataWhenServicePointWithoutUser() throws SystemException {
         Branch branch = new Branch("b2", "Отделение №2");
@@ -218,7 +218,7 @@ class VisitServiceCreateVirtualVisit2Test {
         assertEquals(primary.getName(), startServing.getParameters().get("serviceName"));
     }
 
-    @DisplayName("Создание VirtualVisit2 выбрасывает исключение «не найдено» при отсутствии очереди в отделении")
+    @DisplayName("Создание виртуального визита выбрасывает исключение «не найдено» при отсутствии очереди в отделении")
     @Test
     void createVirtualVisit2ThrowsNotFoundWhenQueueMissingInBranch() throws SystemException {
         Branch branch = new Branch("b3", "Отделение №3");

--- a/src/test/unit/java/ru/aritmos/service/VisitServiceCreateVirtualVisitTest.java
+++ b/src/test/unit/java/ru/aritmos/service/VisitServiceCreateVirtualVisitTest.java
@@ -55,7 +55,7 @@ class VisitServiceCreateVirtualVisitTest {
     }
 
     /** Убеждаемся, что в createVirtualVisit2 передаются клоны услуг и исходные параметры. */
-    @DisplayName("Передаёт клонированные услуги при создании VirtualVisit2")
+    @DisplayName("Передаёт клонированные услуги при создании виртуального визита")
     @Test
     void passesClonedServicesToCreateVirtualVisit2() throws SystemException {
         VisitService service = spy(new VisitService());

--- a/src/test/unit/java/ru/aritmos/service/VisitServiceCreateVisit2FromReceptionLegacyTest.java
+++ b/src/test/unit/java/ru/aritmos/service/VisitServiceCreateVisit2FromReceptionLegacyTest.java
@@ -33,7 +33,7 @@ import ru.aritmos.test.TestLoggingExtension;
 @ExtendWith(TestLoggingExtension.class)
 class VisitServiceCreateVisit2FromReceptionLegacyTest {
 
-    @DisplayName("createVisit2FromReception создаёт визит и печатает талон, когда сегментация возвращает очередь")
+    @DisplayName("Создание визита из приёмной печатает талон, когда сегментация возвращает очередь")
     @Test
     void createsVisitAndPrintsTicketWhenSegmentationReturnsQueue() throws Exception {
         VisitService service = new VisitService();
@@ -138,7 +138,7 @@ class VisitServiceCreateVisit2FromReceptionLegacyTest {
         verifyNoMoreInteractions(printerService);
     }
 
-    @DisplayName("createVisit2FromReception не печатает талон при отключённом флаге и отсутствии сотрудника")
+    @DisplayName("Создание визита из приёмной не печатает талон при отключённом флаге и отсутствии сотрудника")
     @Test
     void doesNotPrintTicketWhenFlagDisabledAndStaffMissing() throws Exception {
         VisitService service = new VisitService();
@@ -221,7 +221,7 @@ class VisitServiceCreateVisit2FromReceptionLegacyTest {
         verify(printerService, never()).print(anyString(), any());
     }
 
-    @DisplayName("createVisit2FromReception возвращает 400, если сегментация не подобрала очередь")
+    @DisplayName("Создание визита из приёмной возвращает 400, если сегментация не подобрала очередь")
     @Test
     void throwsBadRequestWhenSegmentationReturnsEmptyQueue() throws Exception {
         VisitService service = new VisitService();
@@ -277,7 +277,7 @@ class VisitServiceCreateVisit2FromReceptionLegacyTest {
         verify(printerService, never()).print(anyString(), any());
     }
 
-    @DisplayName("createVisit2FromReception возвращает 404 при отсутствии очереди в конфигурации отделения")
+    @DisplayName("Создание визита из приёмной возвращает 404 при отсутствии очереди в конфигурации отделения")
     @Test
     void throwsNotFoundWhenQueueMissingInBranchConfiguration() throws Exception {
         VisitService service = new VisitService();

--- a/src/test/unit/java/ru/aritmos/service/VisitServiceCreateVisit2FromReceptionTest.java
+++ b/src/test/unit/java/ru/aritmos/service/VisitServiceCreateVisit2FromReceptionTest.java
@@ -33,7 +33,7 @@ import ru.aritmos.test.TestLoggingExtension;
 @ExtendWith(TestLoggingExtension.class)
 class VisitServiceCreateVisit2FromReceptionTest {
 
-    @DisplayName("createVisit2FromReception с правилом сегментации создаёт визит и печатает талон")
+    @DisplayName("Метод `createVisit2FromReception` с правилом сегментации создаёт визит и печатает талон")
     @Test
     void createsVisitWithSegmentationRuleAndPrintsTicket() {
         VisitService service = new VisitService();
@@ -141,7 +141,7 @@ class VisitServiceCreateVisit2FromReceptionTest {
         verifyNoMoreInteractions(printerService);
     }
 
-    @DisplayName("createVisit2FromReception возвращает 400, если правило сегментации не подобрало очередь")
+    @DisplayName("Метод `createVisit2FromReception` возвращает код 400, если правило сегментации не подобрало очередь")
     @Test
     void throwsBadRequestWhenSegmentationRuleReturnsEmptyQueue() {
         VisitService service = new VisitService();
@@ -201,7 +201,7 @@ class VisitServiceCreateVisit2FromReceptionTest {
         verify(service.printerService, never()).print(anyString(), any());
     }
 
-    @DisplayName("createVisit2FromReception возвращает 404 при отсутствии очереди в конфигурации отделения")
+    @DisplayName("Метод `createVisit2FromReception` возвращает код 404 при отсутствии очереди в конфигурации отделения")
     @Test
     void throwsNotFoundWhenQueueMissingInBranchConfiguration() {
         VisitService service = new VisitService();

--- a/src/test/unit/java/ru/aritmos/service/VisitServiceCreateVisit2Test.java
+++ b/src/test/unit/java/ru/aritmos/service/VisitServiceCreateVisit2Test.java
@@ -35,7 +35,7 @@ import ru.aritmos.test.TestLoggingExtension;
 @ExtendWith(TestLoggingExtension.class)
 class VisitServiceCreateVisit2Test {
 
-    @DisplayName("createVisit2 создаёт визит и печатает талон при найденной очереди")
+    @DisplayName("Расширенное создание визита печатает талон при найденной очереди")
     @Test
     void createsVisitAndPrintsTicketWhenQueueFound() throws SystemException {
         VisitService service = new VisitService();
@@ -143,7 +143,7 @@ class VisitServiceCreateVisit2Test {
         verifyNoInteractions(eventService);
     }
 
-    @DisplayName("createVisit2 возвращает 404 при пустом списке услуг")
+    @DisplayName("Расширенное создание визита возвращает 404 при пустом списке услуг")
     @Test
     void throwsNotFoundWhenServicesListEmpty() throws SystemException {
         VisitService service = new VisitService();
@@ -180,7 +180,7 @@ class VisitServiceCreateVisit2Test {
         verify(printerService, never()).print(anyString(), any());
     }
 
-    @DisplayName("createVisit2 возвращает 404 при отсутствии основной услуги в отделении")
+    @DisplayName("Расширенное создание визита возвращает 404 при отсутствии основной услуги в отделении")
     @Test
     void throwsNotFoundWhenPrimaryServiceMissingInBranch() throws SystemException {
         VisitService service = new VisitService();
@@ -218,7 +218,7 @@ class VisitServiceCreateVisit2Test {
         verify(printerService, never()).print(anyString(), any());
     }
 
-    @DisplayName("createVisit2 возвращает 404 при отсутствии терминала")
+    @DisplayName("Расширенное создание визита возвращает 404 при отсутствии терминала")
     @Test
     void throwsNotFoundWhenEntryPointMissing() throws SystemException {
         VisitService service = new VisitService();
@@ -264,7 +264,7 @@ class VisitServiceCreateVisit2Test {
         verify(printerService, never()).print(anyString(), any());
     }
 
-    @DisplayName("createVisit2 возвращает 400, если правило сегментации не подобрало очередь")
+    @DisplayName("Расширенное создание визита возвращает 400, если правило сегментации не подобрало очередь")
     @Test
     void throwsBadRequestWhenSegmentationRuleReturnsEmptyQueue() throws SystemException {
         VisitService service = new VisitService();
@@ -322,7 +322,7 @@ class VisitServiceCreateVisit2Test {
         verify(printerService, never()).print(anyString(), any());
     }
 
-    @DisplayName("createVisit2 возвращает 404, если очередь отсутствует в конфигурации отделения")
+    @DisplayName("Расширенное создание визита возвращает 404, если очередь отсутствует в конфигурации отделения")
     @Test
     void throwsNotFoundWhenQueueMissingInBranchConfiguration() throws SystemException {
         VisitService service = new VisitService();

--- a/src/test/unit/java/ru/aritmos/service/VisitServiceCreateVisit2WithSegmentationRuleTest.java
+++ b/src/test/unit/java/ru/aritmos/service/VisitServiceCreateVisit2WithSegmentationRuleTest.java
@@ -30,7 +30,7 @@ import ru.aritmos.test.TestLoggingExtension;
 @ExtendWith(TestLoggingExtension.class)
 class VisitServiceCreateVisit2WithSegmentationRuleTest {
 
-    @DisplayName("createVisit2 с правилом сегментации создаёт визит и печатает талон при наличии очереди")
+    @DisplayName("Создание визита по правилу сегментации печатает талон при найденной очереди")
     @Test
     void createsVisitAndPrintsTicketWhenSegmentationRuleProvidesQueue() throws Exception {
         VisitService service = new VisitService();
@@ -137,7 +137,7 @@ class VisitServiceCreateVisit2WithSegmentationRuleTest {
         verifyNoInteractions(eventService);
     }
 
-    @DisplayName("createVisit2 с правилом сегментации возвращает 400, если правило не подобрало очередь")
+    @DisplayName("Создание визита по правилу сегментации возвращает 400, если очередь не подобрана")
     @Test
     void throwsBadRequestWhenSegmentationRuleReturnsEmptyQueue() {
         VisitService service = new VisitService();
@@ -195,7 +195,7 @@ class VisitServiceCreateVisit2WithSegmentationRuleTest {
         verify(printerService, never()).print(anyString(), any());
     }
 
-    @DisplayName("createVisit2 с правилом сегментации возвращает 404 при отсутствии терминала в отделении")
+    @DisplayName("Создание визита по правилу сегментации возвращает 404 при отсутствии терминала в отделении")
     @Test
     void throwsNotFoundWhenEntryPointMissingInBranch() {
         VisitService service = new VisitService();

--- a/src/test/unit/java/ru/aritmos/service/VisitServiceCreateVisitFromReceptionTest.java
+++ b/src/test/unit/java/ru/aritmos/service/VisitServiceCreateVisitFromReceptionTest.java
@@ -27,7 +27,7 @@ import ru.aritmos.test.TestLoggingExtension;
 @ExtendWith(TestLoggingExtension.class)
 class VisitServiceCreateVisitFromReceptionTest {
 
-    @DisplayName("createVisitFromReception делегирует вызов createVisit2FromReception")
+    @DisplayName("Создание визита на терминале переиспользует расширенный сценарий приёмной")
     @Test
     void createVisitFromReceptionDelegatesToCreateVisit2FromReception() throws SystemException {
         Branch branch = new Branch("b1", "Отделение");
@@ -61,7 +61,7 @@ class VisitServiceCreateVisitFromReceptionTest {
         assertNotSame(second, service.lastServices.get(1));
     }
 
-    @DisplayName("createVisitFromReception выбрасывает исключение при отсутствии услуги")
+    @DisplayName("Создание визита на терминале завершается ошибкой при отсутствии услуги")
     @Test
     void createVisitFromReceptionThrowsWhenServiceMissing() {
         Branch branch = new Branch("b1", "Отделение");
@@ -85,7 +85,7 @@ class VisitServiceCreateVisitFromReceptionTest {
         assertFalse(service.visitAutoCallInvoked);
     }
 
-    @DisplayName("createVisitFromReception выбрасывает исключение при пустом списке услуг")
+    @DisplayName("Создание визита на терминале завершается ошибкой при пустом списке услуг")
     @Test
     void createVisitFromReceptionThrowsWhenServiceListEmpty() {
         Branch branch = new Branch("b1", "Отделение");
@@ -106,7 +106,7 @@ class VisitServiceCreateVisitFromReceptionTest {
         assertFalse(service.visitAutoCallInvoked);
     }
 
-    @DisplayName("createVisitFromReception с правилом сегментации делегирует вызов")
+    @DisplayName("Создание визита на терминале с правилом сегментации переиспользует расширенный сценарий")
     @Test
     void createVisitFromReceptionWithSegmentationRuleDelegates() {
         Branch branch = new Branch("b1", "Отделение");
@@ -133,7 +133,7 @@ class VisitServiceCreateVisitFromReceptionTest {
         assertTrue(service.visitAutoCallInvoked);
     }
 
-    @DisplayName("createVisitFromReception с правилом сегментации выбрасывает исключение при отсутствии услуги")
+    @DisplayName("Создание визита на терминале с правилом сегментации завершается ошибкой при отсутствии услуги")
     @Test
     void createVisitFromReceptionWithSegmentationRuleThrowsWhenServiceMissing() {
         Branch branch = new Branch("b1", "Отделение");

--- a/src/test/unit/java/ru/aritmos/service/VisitServiceCreateVisitTest.java
+++ b/src/test/unit/java/ru/aritmos/service/VisitServiceCreateVisitTest.java
@@ -27,7 +27,7 @@ import ru.aritmos.test.TestLoggingExtension;
 @ExtendWith(TestLoggingExtension.class)
 class VisitServiceCreateVisitTest {
 
-    @DisplayName("createVisit делегирует вызов createVisit2 с клонированными услугами")
+    @DisplayName("Базовое создание визита переиспользует расширенный сценарий с клонированными услугами")
     @Test
     void createVisitDelegatesToCreateVisit2WithClonedServices() throws SystemException {
         Branch branch = new Branch("b1", "Отделение");
@@ -60,7 +60,7 @@ class VisitServiceCreateVisitTest {
         assertNotSame(second, service.lastServices.get(1));
     }
 
-    @DisplayName("createVisit выбрасывает исключение при отсутствии услуги")
+    @DisplayName("Базовое создание визита завершается ошибкой при отсутствии услуги")
     @Test
     void createVisitThrowsWhenServiceMissing() {
         Branch branch = new Branch("b1", "Отделение");
@@ -83,7 +83,7 @@ class VisitServiceCreateVisitTest {
         assertFalse(service.visitAutoCallInvoked);
     }
 
-    @DisplayName("createVisit выбрасывает исключение при пустом списке услуг")
+    @DisplayName("Базовое создание визита завершается ошибкой при пустом списке услуг")
     @Test
     void createVisitThrowsWhenServiceListEmpty() {
         Branch branch = new Branch("b1", "Отделение");
@@ -103,7 +103,7 @@ class VisitServiceCreateVisitTest {
         assertFalse(service.visitAutoCallInvoked);
     }
 
-    @DisplayName("createVisit с правилом сегментации делегирует в createVisit2")
+    @DisplayName("Базовое создание визита с правилом сегментации переиспользует расширенный сценарий")
     @Test
     void createVisitWithSegmentationRuleDelegatesToCreateVisit2() {
         Branch branch = new Branch("b1", "Отделение");
@@ -129,7 +129,7 @@ class VisitServiceCreateVisitTest {
         assertTrue(visitService.visitAutoCallInvoked);
     }
 
-    @DisplayName("createVisit с правилом сегментации выбрасывает исключение при отсутствии услуги")
+    @DisplayName("Базовое создание визита с правилом сегментации завершается ошибкой при отсутствии услуги")
     @Test
     void createVisitWithSegmentationRuleThrowsWhenServiceMissing() {
         Branch branch = new Branch("b1", "Отделение");

--- a/src/test/unit/java/ru/aritmos/service/VisitServiceDeleteVisitTest.java
+++ b/src/test/unit/java/ru/aritmos/service/VisitServiceDeleteVisitTest.java
@@ -37,7 +37,7 @@ class VisitServiceDeleteVisitTest {
         resetVisitEvent();
     }
 
-    @DisplayName("deleteVisit очищает привязки визита и уведомляет отделение")
+    @DisplayName("Метод `deleteVisit` очищает привязки визита и уведомляет отделение")
     @Test
     void deleteVisitClearsAssignmentsAndNotifiesBranch() {
         LOG.info("Шаг 1: создаём визит с привязкой к очереди и точке обслуживания");
@@ -70,7 +70,7 @@ class VisitServiceDeleteVisitTest {
         verifyNoInteractions(service.eventService);
     }
 
-    @DisplayName("deleteVisit выбрасывает исключение, если задержка возврата не истекла")
+    @DisplayName("Метод `deleteVisit` выбрасывает исключение, если задержка возврата не истекла")
     @Test
     void deleteVisitThrowsWhenReturnDelayNotElapsed() {
         LOG.info("Шаг 1: готовим визит, недавно вернувшийся в очередь");
@@ -100,7 +100,7 @@ class VisitServiceDeleteVisitTest {
         assertEquals("sp-1", visit.getServicePointId());
     }
 
-    @DisplayName("deleteVisit выбрасывает исключение, если задержка перевода не истекла")
+    @DisplayName("Метод `deleteVisit` выбрасывает исключение, если задержка перевода не истекла")
     @Test
     void deleteVisitThrowsWhenTransferDelayNotElapsed() {
         LOG.info("Шаг 1: формируем визит, недавно переведённый из очереди");

--- a/src/test/unit/java/ru/aritmos/service/VisitServiceDeliveredServicesTest.java
+++ b/src/test/unit/java/ru/aritmos/service/VisitServiceDeliveredServicesTest.java
@@ -23,7 +23,7 @@ import ru.aritmos.model.visit.VisitEvent;
  */
 class VisitServiceDeliveredServicesTest {
 
-    @DisplayName("getDeliveredServices возвращает фактические услуги текущей услуги визита")
+    @DisplayName("Метод `getDeliveredServices` возвращает фактические услуги текущей услуги визита")
     @Test
     void returnsDeliveredServicesOfCurrentService() {
         VisitService service = new VisitService();
@@ -56,7 +56,7 @@ class VisitServiceDeliveredServicesTest {
         assertSame(delivered, result.get("ds1"));
     }
 
-    @DisplayName("getDeliveredServices выбрасывает исключение при отсутствии текущей услуги")
+    @DisplayName("Метод `getDeliveredServices` выбрасывает исключение при отсутствии текущей услуги")
     @Test
     void throwsWhenCurrentServiceMissing() {
         VisitService service = new VisitService();
@@ -78,7 +78,7 @@ class VisitServiceDeliveredServicesTest {
         verify(eventService).send(eq("*"), eq(false), any());
     }
 
-    @DisplayName("addDeliveredService добавляет фактическую услугу к текущей услуге")
+    @DisplayName("Метод `addDeliveredService` добавляет фактическую услугу к текущей услуге")
     @Test
     void addDeliveredServiceAddsToCurrentService() {
         Branch branch = new Branch("b1", "Branch");
@@ -110,7 +110,7 @@ class VisitServiceDeliveredServicesTest {
         verify(branchService).updateVisit(eq(visit), any(VisitEvent.class), eq(service));
     }
 
-    @DisplayName("deleteDeliveredService удаляет фактическую услугу из текущей услуги")
+    @DisplayName("Метод `deleteDeliveredService` удаляет фактическую услугу из текущей услуги")
     @Test
     void deleteDeliveredServiceRemovesFromCurrentService() {
         Branch branch = new Branch("b1", "Branch");
@@ -142,7 +142,7 @@ class VisitServiceDeliveredServicesTest {
     }
 
 
-    @DisplayName("addOutcomeOfDeliveredService устанавливает исход фактической услуги")
+    @DisplayName("Метод `addOutcomeOfDeliveredService` устанавливает исход фактической услуги")
     @Test
     void addOutcomeOfDeliveredServiceSetsOutcome() {
         Branch branch = new Branch("b1", "Branch");
@@ -174,7 +174,7 @@ class VisitServiceDeliveredServicesTest {
         verify(branchService).updateVisit(eq(visit), any(VisitEvent.class), eq(service));
     }
 
-    @DisplayName("addOutcomeOfDeliveredService выбрасывает исключение при отсутствии фактической услуги")
+    @DisplayName("Метод `addOutcomeOfDeliveredService` выбрасывает исключение при отсутствии фактической услуги")
     @Test
     void addOutcomeOfDeliveredServiceThrowsWhenMissingDeliveredService() {
         Branch branch = new Branch("b1", "Branch");
@@ -201,7 +201,7 @@ class VisitServiceDeliveredServicesTest {
         verify(eventService).send(eq("*"), eq(false), any());
     }
 
-    @DisplayName("deleteOutcomeDeliveredService очищает исход фактической услуги")
+    @DisplayName("Метод `deleteOutcomeDeliveredService` очищает исход фактической услуги")
     @Test
     void deleteOutcomeDeliveredServiceClearsOutcome() {
         Branch branch = new Branch("b1", "Branch");

--- a/src/test/unit/java/ru/aritmos/service/VisitServiceGetMarksTest.java
+++ b/src/test/unit/java/ru/aritmos/service/VisitServiceGetMarksTest.java
@@ -21,7 +21,7 @@ import ru.aritmos.model.visit.Visit;
  */
 class VisitServiceGetMarksTest {
 
-    @DisplayName("getMarks возвращает метки визита")
+    @DisplayName("Метод `getMarks` возвращает метки визита")
     @Test
     void returnsMarksOfVisit() {
         Branch branch = new Branch("b1", "Branch");
@@ -50,7 +50,7 @@ class VisitServiceGetMarksTest {
         assertSame(mark, marks.get(0));
     }
 
-    @DisplayName("getMarks выбрасывает исключение при отсутствии визита")
+    @DisplayName("Метод `getMarks` выбрасывает исключение при отсутствии визита")
     @Test
     void throwsWhenVisitMissing() {
         Branch branch = new Branch("b1", "Branch");

--- a/src/test/unit/java/ru/aritmos/service/VisitServiceGetVisitsTest.java
+++ b/src/test/unit/java/ru/aritmos/service/VisitServiceGetVisitsTest.java
@@ -22,7 +22,7 @@ import ru.aritmos.model.visit.Visit;
 class VisitServiceGetVisitsTest {
 
     /** Проверяет фильтрацию визитов и сортировку по времени ожидания. */
-    @DisplayName("getVisits фильтрует и сортирует визиты")
+    @DisplayName("Метод `getVisits` фильтрует и сортирует визиты")
     @Test
     void filtersAndSortsVisits() {
         VisitService service = new VisitService();
@@ -58,7 +58,7 @@ class VisitServiceGetVisitsTest {
     }
 
     /** Проверяет фильтрацию по ограничению времени перевода визита. */
-    @DisplayName("getVisits учитывает ограничение по времени перевода")
+    @DisplayName("Метод `getVisits` учитывает ограничение по времени перевода")
     @Test
     void filtersVisitsByTransferDelay() {
         VisitService service = new VisitService();
@@ -97,7 +97,7 @@ class VisitServiceGetVisitsTest {
     }
 
     /** Ограничивает количество возвращаемых визитов. */
-    @DisplayName("getVisits ограничивает количество возвращаемых визитов")
+    @DisplayName("Метод `getVisits` ограничивает количество возвращаемых визитов")
     @Test
     void limitsNumberOfVisits() {
         VisitService service = new VisitService();
@@ -123,7 +123,7 @@ class VisitServiceGetVisitsTest {
     }
 
     /** Бросает HTTP-исключение, если очередь не найдена. */
-    @DisplayName("getVisits выбрасывает исключение при отсутствии очереди")
+    @DisplayName("Метод `getVisits` выбрасывает исключение при отсутствии очереди")
     @Test
     void throwsWhenQueueMissing() {
         VisitService service = new VisitService();

--- a/src/test/unit/java/ru/aritmos/service/VisitServiceMarkLookupByIdTest.java
+++ b/src/test/unit/java/ru/aritmos/service/VisitServiceMarkLookupByIdTest.java
@@ -26,7 +26,7 @@ class VisitServiceMarkLookupByIdTest {
 
     private static final Logger LOG = LoggerFactory.getLogger(VisitServiceMarkLookupByIdTest.class);
 
-    @DisplayName("addMark по идентификатору делегирует существующей отметке")
+    @DisplayName("Метод `addMark` по идентификатору делегирует существующей отметке")
     @Test
     void addMarkByIdDelegatesToExistingMark() {
         LOG.info("Шаг 1: создаём отделение с преднастроенной заметкой");
@@ -56,7 +56,7 @@ class VisitServiceMarkLookupByIdTest {
         verifyNoInteractions(eventService);
     }
 
-    @DisplayName("addMark по идентификатору выбрасывает исключение при отсутствии отметки")
+    @DisplayName("Метод `addMark` по идентификатору выбрасывает исключение при отсутствии отметки")
     @Test
     void addMarkByIdThrowsWhenMarkMissing() {
         LOG.info("Шаг 1: создаём отделение без требуемой заметки");
@@ -79,7 +79,7 @@ class VisitServiceMarkLookupByIdTest {
         verify(eventService).send(eq("*"), eq(false), any());
     }
 
-    @DisplayName("deleteMark по идентификатору делегирует существующей отметке")
+    @DisplayName("Метод `deleteMark` по идентификатору делегирует существующей отметке")
     @Test
     void deleteMarkByIdDelegatesToExistingMark() {
         LOG.info("Шаг 1: создаём отделение с заметкой для удаления");
@@ -109,7 +109,7 @@ class VisitServiceMarkLookupByIdTest {
         verifyNoInteractions(eventService);
     }
 
-    @DisplayName("deleteMark по идентификатору выбрасывает исключение при отсутствии отметки")
+    @DisplayName("Метод `deleteMark` по идентификатору выбрасывает исключение при отсутствии отметки")
     @Test
     void deleteMarkByIdThrowsWhenMarkMissing() {
         LOG.info("Шаг 1: подготавливаем отделение без искомой заметки");

--- a/src/test/unit/java/ru/aritmos/service/VisitServiceMaxCallRulesTest.java
+++ b/src/test/unit/java/ru/aritmos/service/VisitServiceMaxCallRulesTest.java
@@ -31,7 +31,7 @@ import ru.aritmos.test.TestLoggingExtension;
 @ExtendWith(TestLoggingExtension.class)
 class VisitServiceMaxCallRulesTest {
 
-    @DisplayName("visitCallWithMaximalWaitingTime использует результат правила")
+    @DisplayName("Метод `visitCallWithMaximalWaitingTime` использует результат правила")
     @Test
     void visitCallWithMaximalWaitingTimeUsesRuleResult() {
         log.info("Готовим отделение и точку обслуживания с оператором для сценария максимального ожидания");
@@ -88,7 +88,7 @@ class VisitServiceMaxCallRulesTest {
         verify(service, times(2)).visitCall(eq(branch.getId()), eq(servicePoint.getId()), any(Visit.class), eq("callNext"));
     }
 
-    @DisplayName("visitCallWithMaximalWaitingTime включает автообзвон при пустом ответе правила")
+    @DisplayName("Метод `visitCallWithMaximalWaitingTime` включает автообзвон при пустом ответе правила")
     @Test
     void visitCallWithMaximalWaitingTimeEnablesAutocallWhenRuleReturnsEmpty() {
         log.info("Настраиваем отделение в режиме авто-вызова для проверки перехода в автодовызов");
@@ -143,7 +143,7 @@ class VisitServiceMaxCallRulesTest {
         verify(branchService, times(2)).add(branch.getId(), branch);
     }
 
-    @DisplayName("visitCallWithMaximalWaitingTime возвращает 404 при отсутствии точки обслуживания")
+    @DisplayName("Метод `visitCallWithMaximalWaitingTime` возвращает код 404 при отсутствии точки обслуживания")
     @Test
     void visitCallWithMaximalWaitingTimeFailsWhenServicePointMissing() {
         log.info("Проверяем сценарий, когда точка обслуживания отсутствует в конфигурации отделения");
@@ -168,7 +168,7 @@ class VisitServiceMaxCallRulesTest {
         assertEquals(HttpStatus.NOT_FOUND, second.getStatus());
     }
 
-    @DisplayName("visitCallWithMaxLifeTime возвращает 404 при отсутствии точки обслуживания")
+    @DisplayName("Метод `visitCallWithMaxLifeTime` возвращает код 404 при отсутствии точки обслуживания")
     @Test
     void visitCallWithMaxLifeTimeFailsWhenServicePointMissing() {
         log.info("Конфигурация отделения не содержит точку обслуживания, ожидаем ошибку при вызове по времени жизни");
@@ -193,7 +193,7 @@ class VisitServiceMaxCallRulesTest {
         assertEquals(HttpStatus.NOT_FOUND, second.getStatus());
     }
 
-    @DisplayName("visitCallWithMaximalWaitingTime возвращает 403 при незалогиненном операторе")
+    @DisplayName("Метод `visitCallWithMaximalWaitingTime` возвращает код 403 при незалогиненном операторе")
     @Test
     void visitCallWithMaximalWaitingTimeFailsWhenUserNotLogged() {
         log.info("Создаём точку обслуживания без оператора и проверяем реакцию метода");
@@ -220,7 +220,7 @@ class VisitServiceMaxCallRulesTest {
         assertEquals(HttpStatus.FORBIDDEN, second.getStatus());
     }
 
-    @DisplayName("visitCallWithMaxLifeTime возвращает 403 при незалогиненном операторе")
+    @DisplayName("Метод `visitCallWithMaxLifeTime` возвращает код 403 при незалогиненном операторе")
     @Test
     void visitCallWithMaxLifeTimeFailsWhenUserNotLogged() {
         log.info("Имитация точки без оператора для правила по времени жизни");
@@ -247,7 +247,7 @@ class VisitServiceMaxCallRulesTest {
         assertEquals(HttpStatus.FORBIDDEN, second.getStatus());
     }
 
-    @DisplayName("visitCallWithMaximalWaitingTime возвращает пусто без автообзвона")
+    @DisplayName("Метод `visitCallWithMaximalWaitingTime` возвращает пустой результат без автодовызова")
     @Test
     void visitCallWithMaximalWaitingTimeReturnsEmptyWhenNoAutoCallConfigured() {
         log.info("Готовим отделение без режима автодовызова и ожидаем пустой результат");
@@ -283,7 +283,7 @@ class VisitServiceMaxCallRulesTest {
         verify(eventService, never()).send(anyString(), anyBoolean(), any(Event.class));
     }
 
-    @DisplayName("visitCallWithMaxLifeTime возвращает пусто без автообзвона")
+    @DisplayName("Метод `visitCallWithMaxLifeTime` возвращает пустой результат без автодовызова")
     @Test
     void visitCallWithMaxLifeTimeReturnsEmptyWhenNoAutoCallConfigured() {
         log.info("Отделение без автодовызова должно возвращать пустой результат при отсутствии кандидатов по времени жизни");
@@ -319,7 +319,7 @@ class VisitServiceMaxCallRulesTest {
         verify(eventService, never()).send(anyString(), anyBoolean(), any(Event.class));
     }
 
-    @DisplayName("visitCallWithMaxLifeTime использует результат правила")
+    @DisplayName("Метод `visitCallWithMaxLifeTime` использует результат правила")
     @Test
     void visitCallWithMaxLifeTimeUsesRuleResult() {
         log.info("Готовим отделение для сценария вызова по максимальному времени жизни визита");
@@ -376,7 +376,7 @@ class VisitServiceMaxCallRulesTest {
         verify(service, times(2)).visitCall(eq(branch.getId()), eq(servicePoint.getId()), any(Visit.class), eq("callNext"));
     }
 
-    @DisplayName("visitCallWithMaxLifeTime включает автообзвон при пустом ответе правила")
+    @DisplayName("Метод `visitCallWithMaxLifeTime` включает автообзвон при пустом ответе правила")
     @Test
     void visitCallWithMaxLifeTimeEnablesAutocallWhenRuleReturnsEmpty() {
         log.info("Создаём отделение с авто-вызовом для проверки поведения правил по времени жизни");

--- a/src/test/unit/java/ru/aritmos/service/VisitServiceNoteTest.java
+++ b/src/test/unit/java/ru/aritmos/service/VisitServiceNoteTest.java
@@ -20,7 +20,7 @@ import ru.aritmos.model.visit.VisitEvent;
 
 class VisitServiceNoteTest {
 
-    @DisplayName("addNote добавляет запись и инициирует обновление визита")
+    @DisplayName("Метод `addNote` добавляет запись и инициирует обновление визита")
     @Test
     void addNoteAppendsNoteAndCallsUpdate() {
         Branch branch = new Branch("b1", "Branch");
@@ -53,7 +53,7 @@ class VisitServiceNoteTest {
         verify(branchService).updateVisit(eq(visit), any(VisitEvent.class), eq(serviceBean));
     }
 
-    @DisplayName("addNote выбрасывает исключение при отсутствии визита")
+    @DisplayName("Метод `addNote` выбрасывает исключение при отсутствии визита")
     @Test
     void addNoteThrowsWhenNoVisit() {
         Branch branch = new Branch("b1", "Branch");
@@ -72,7 +72,7 @@ class VisitServiceNoteTest {
         verify(eventService).send(eq("*"), eq(false), any());
     }
 
-    @DisplayName("getNotes возвращает заметки визита")
+    @DisplayName("Метод `getNotes` возвращает заметки визита")
     @Test
     void getNotesReturnsNotes() {
         Branch branch = new Branch("b1", "Branch");
@@ -102,7 +102,7 @@ class VisitServiceNoteTest {
         assertEquals("note", notes.get(0).getValue());
     }
 
-    @DisplayName("getNotes выбрасывает исключение при отсутствии визита")
+    @DisplayName("Метод `getNotes` выбрасывает исключение при отсутствии визита")
     @Test
     void getNotesThrowsWhenVisitMissing() {
         Branch branch = new Branch("b1", "Branch");

--- a/src/test/unit/java/ru/aritmos/service/VisitServiceTest.java
+++ b/src/test/unit/java/ru/aritmos/service/VisitServiceTest.java
@@ -466,7 +466,7 @@ class VisitServiceTest {
         assertTrue(result.containsKey("sp2"));
     }
 
-    @DisplayName("Получение рабочих профилей возвращает Tiny-модели")
+    @DisplayName("Получение рабочих профилей возвращает компактные модели Tiny")
     @Test
     void getWorkProfilesReturnsTinyClasses() {
         Branch branch = new Branch("b1", "Branch");

--- a/src/test/unit/java/ru/aritmos/service/VisitServiceTransferFromQueueTest.java
+++ b/src/test/unit/java/ru/aritmos/service/VisitServiceTransferFromQueueTest.java
@@ -203,7 +203,7 @@ class VisitServiceTransferFromQueueTest {
         assertEquals(visit.getTicket(), body.get("ticket"));
     }
 
-    @DisplayName("Перенос визита во внешнюю очередь передаёт данные услуги и идентификатор SID")
+    @DisplayName("Перенос визита во внешнюю очередь передаёт данные услуги и идентификатор `SID`")
     @Test
     void visitTransferToQueueFromExternalServicePropagatesServiceInfoAndSid() {
         log.info("Готовим отделение с очередями и заполняем информацию Keycloak");

--- a/src/test/unit/java/ru/aritmos/service/VisitServiceUncoveredOperationsTest.java
+++ b/src/test/unit/java/ru/aritmos/service/VisitServiceUncoveredOperationsTest.java
@@ -297,7 +297,7 @@ class VisitServiceUncoveredOperationsTest {
         assertEquals(activePoint.getId(), backEvent.getParameters().get("servicePointId"));
     }
 
-    @DisplayName("Перенос визита с объектом Visit ставит запись в начало при соответствующем запросе")
+    @DisplayName("Перенос визита, переданного объектом `Visit`, ставит запись в начало при соответствующем запросе")
     @Test
     void visitTransferWithVisitEntityPlacesToStartWhenRequested() {
         log.info("Подготавливаем отделение с точкой обслуживания и двумя очередями");

--- a/src/test/unit/java/ru/aritmos/service/VisitServiceVisitConfirmTest.java
+++ b/src/test/unit/java/ru/aritmos/service/VisitServiceVisitConfirmTest.java
@@ -42,7 +42,7 @@ class VisitServiceVisitConfirmTest {
         VisitEvent.START_SERVING.getParameters().clear();
     }
 
-    @DisplayName("Подтверждение визита переводит клиента к точке обслуживания и публикует событие START_SERVING")
+    @DisplayName("Подтверждение визита переводит клиента к точке обслуживания и публикует событие `START_SERVING`")
     @Test
     void visitConfirmMovesVisitToServicePointAndPublishesStartServingEvent() {
         log.info("Готовим отделение и точку обслуживания для позитивного сценария подтверждения визита");

--- a/src/test/unit/java/ru/aritmos/service/rules/CallRuleTest.java
+++ b/src/test/unit/java/ru/aritmos/service/rules/CallRuleTest.java
@@ -21,7 +21,7 @@ class CallRuleTest {
         assertTrue(Rule.class.isAssignableFrom(CallRule.class));
     }
 
-    @DisplayName("Метод вызова без фильтра очередей возвращает Optional с визитом")
+    @DisplayName("Метод вызова без фильтра очередей возвращает `Optional` с визитом")
     @Test
     void callMethodWithoutQueueFilterShouldReturnOptionalVisit() throws NoSuchMethodException {
         Method method = CallRule.class.getMethod("call", Branch.class, ServicePoint.class);
@@ -32,7 +32,7 @@ class CallRuleTest {
         assertEquals(Visit.class, elementType);
     }
 
-    @DisplayName("Метод вызова с фильтром очередей возвращает Optional с визитом")
+    @DisplayName("Метод вызова с фильтром очередей возвращает `Optional` с визитом")
     @Test
     void callMethodWithQueueFilterShouldReturnOptionalVisit() throws NoSuchMethodException {
         Method method = CallRule.class.getMethod("call", Branch.class, ServicePoint.class, List.class);

--- a/src/test/unit/java/ru/aritmos/service/rules/MaxWaitingTimeCallRuleTest.java
+++ b/src/test/unit/java/ru/aritmos/service/rules/MaxWaitingTimeCallRuleTest.java
@@ -21,7 +21,7 @@ import ru.aritmos.model.visit.Visit;
 class MaxWaitingTimeCallRuleTest {
 
     /** Проверяем корректный парсинг даты из строки. */
-    @DisplayName("getDateNyString корректно парсит дату из строки")
+    @DisplayName("Метод `getDateNyString` корректно парсит дату из строки")
     @Test
     void parseDateFromString() {
         MaxWaitingTimeCallRule rule = new MaxWaitingTimeCallRule();
@@ -35,7 +35,7 @@ class MaxWaitingTimeCallRuleTest {
     /**
      * Проверяем отбор доступных точек обслуживания по рабочему профилю.
      */
-    @DisplayName("getAvailiableServicePoints фильтрует точки по рабочему профилю")
+    @DisplayName("Метод `getAvailiableServicePoints` фильтрует точки по рабочему профилю")
     @Test
     void availableServicePointsFilteredByWorkProfile() {
         // создаем отделение
@@ -86,7 +86,7 @@ class MaxWaitingTimeCallRuleTest {
     /**
      * Проверяем, что при неверном рабочем профиле выбрасывается исключение.
      */
-    @DisplayName("call выбрасывает исключение при неверном рабочем профиле")
+    @DisplayName("Метод `call` выбрасывает исключение при неверном рабочем профиле")
     @Test
     void callThrowsWhenWorkProfileIsWrong() {
         MaxWaitingTimeCallRule rule = new MaxWaitingTimeCallRule();
@@ -106,7 +106,7 @@ class MaxWaitingTimeCallRuleTest {
     }
 
     /** Проверяем вызов визита по максимальному ожиданию из списка очередей. */
-    @DisplayName("call с очередями выбирает визит с максимальным ожиданием")
+    @DisplayName("Метод `call` с очередями выбирает визит с максимальным ожиданием")
     @Test
     void callWithQueueIdsSelectsVisit() {
         MaxWaitingTimeCallRule rule = new MaxWaitingTimeCallRule();
@@ -144,7 +144,7 @@ class MaxWaitingTimeCallRuleTest {
     }
 
     /** Проверяем, что без пользователя выбрасывается исключение при вызове с очередями. */
-    @DisplayName("call с очередями выбрасывает исключение без оператора")
+    @DisplayName("Метод `call` с очередями выбрасывает исключение без оператора")
     @Test
     void callWithQueueIdsWithoutUserThrows() {
         MaxWaitingTimeCallRule rule = new MaxWaitingTimeCallRule();
@@ -159,7 +159,7 @@ class MaxWaitingTimeCallRuleTest {
     }
 
     /** Проверяем работу компаратора перенесённых визитов. */
-    @DisplayName("visitComparer учитывает флаги переноса визита")
+    @DisplayName("Метод `visitComparer` учитывает флаги переноса визита")
     @Test
     void visitComparerHandlesTransferFlags() throws Exception {
         MaxWaitingTimeCallRule rule = new MaxWaitingTimeCallRule();
@@ -183,7 +183,7 @@ class MaxWaitingTimeCallRuleTest {
     }
 
     /** Проверяем выбор визита с максимальным временем ожидания без списка очередей. */
-    @DisplayName("call выбирает визит с наибольшим временем ожидания")
+    @DisplayName("Метод `call` выбирает визит с наибольшим временем ожидания")
     @Test
     void callSelectsVisitWithLongestWaitingTime() {
         MaxWaitingTimeCallRule rule = new MaxWaitingTimeCallRule();
@@ -224,7 +224,7 @@ class MaxWaitingTimeCallRuleTest {
     }
 
     /** Проверяем очистку флагов переноса/возврата после выбора визита. */
-    @DisplayName("call сбрасывает временные флаги переноса у выбранного визита")
+    @DisplayName("Метод `call` сбрасывает временные флаги переноса у выбранного визита")
     @Test
     void callResetsTransferFlagsOnSelectedVisit() {
         MaxWaitingTimeCallRule rule = new MaxWaitingTimeCallRule();
@@ -265,7 +265,7 @@ class MaxWaitingTimeCallRuleTest {
     }
 
     /** Проверяем, что при отсутствии пользователя выбрасывается исключение. */
-    @DisplayName("call выбрасывает исключение при отсутствии оператора")
+    @DisplayName("Метод `call` выбрасывает исключение при отсутствии оператора")
     @Test
     void callThrowsWhenNoUserAssigned() {
         MaxWaitingTimeCallRule rule = new MaxWaitingTimeCallRule();
@@ -282,7 +282,7 @@ class MaxWaitingTimeCallRuleTest {
     }
 
     /** Проверяем, что компаратор учитывает порядок по датам переноса. */
-    @DisplayName("visitComparer отдаёт приоритет более ранней дате переноса")
+    @DisplayName("Метод `visitComparer` отдаёт приоритет более ранней дате переноса")
     @Test
     void visitComparerPrefersEarlierTransferDates() throws Exception {
         MaxWaitingTimeCallRule rule = new MaxWaitingTimeCallRule();
@@ -306,7 +306,7 @@ class MaxWaitingTimeCallRuleTest {
     }
 
     /** Проверяем, что визиты без статуса WAITING игнорируются. */
-    @DisplayName("call игнорирует визиты без статуса ожидания")
+    @DisplayName("Метод `call` игнорирует визиты без статуса ожидания")
     @Test
     void callIgnoresVisitsWithoutWaitingStatus() {
         MaxWaitingTimeCallRule rule = new MaxWaitingTimeCallRule();
@@ -337,7 +337,7 @@ class MaxWaitingTimeCallRuleTest {
     }
 
     /** Проверяем, что визиты с ненабранной задержкой возвращения пропускаются. */
-    @DisplayName("call пропускает визиты до истечения задержки возврата")
+    @DisplayName("Метод `call` пропускает визиты до истечения задержки возврата")
     @Test
     void callSkipsVisitsUntilReturnDelayReached() {
         MaxWaitingTimeCallRule rule = new MaxWaitingTimeCallRule();
@@ -381,7 +381,7 @@ class MaxWaitingTimeCallRuleTest {
     }
 
     /** Проверяем очистку временных полей при выборе визита через список очередей. */
-    @DisplayName("call с очередями сбрасывает временные флаги переноса")
+    @DisplayName("Метод `call` с очередями сбрасывает временные флаги переноса")
     @Test
     void callWithQueueIdsResetsTemporaryFlags() {
         MaxWaitingTimeCallRule rule = new MaxWaitingTimeCallRule();
@@ -421,7 +421,7 @@ class MaxWaitingTimeCallRuleTest {
     }
 
     /** Проверяем, что при выборе по списку очередей визиты с задержкой возвращения не подходят. */
-    @DisplayName("call с очередями возвращает пусто до истечения задержки возврата")
+    @DisplayName("Метод `call` с очередями возвращает пустой результат до истечения задержки возврата")
     @Test
     void callWithQueueIdsReturnsEmptyWhenReturnDelayNotMet() {
         MaxWaitingTimeCallRule rule = new MaxWaitingTimeCallRule();
@@ -455,7 +455,7 @@ class MaxWaitingTimeCallRuleTest {
     }
 
     /** Проверяем, что без подходящих пользователей список точек обслуживания пуст. */
-    @DisplayName("getAvailiableServicePoints возвращает пусто без активных операторов")
+    @DisplayName("Метод `getAvailiableServicePoints` возвращает пустой список без активных операторов")
     @Test
     void availableServicePointsReturnEmptyWhenNoActiveUsers() {
         Branch branch = new Branch("b1", "branch");

--- a/src/test/unit/java/ru/aritmos/service/rules/SegmentationRuleTest.java
+++ b/src/test/unit/java/ru/aritmos/service/rules/SegmentationRuleTest.java
@@ -47,7 +47,7 @@ class SegmentationRuleTest {
     }
 
     /** Проверяем выбор очереди при совпадении правил сегментации. */
-    @DisplayName("Returns Queue When Rule Matches")
+    @DisplayName("Правило возвращает очередь при совпадении условий")
     @Test
     void returnsQueueWhenRuleMatches() throws SystemException {
         LOG.info("Шаг 1: создаём отделение с очередью и данными сегментации");
@@ -81,7 +81,7 @@ class SegmentationRuleTest {
     }
 
     /** Проверяем обработку отсутствующего правила сегментации. */
-    @DisplayName("Throws When Segmentation Rule Missing")
+    @DisplayName("При отсутствии правила сегментации выбрасывается исключение")
     @Test
     void throwsWhenSegmentationRuleMissing() {
         LOG.info("Шаг 1: настраиваем мок сервиса отделений и визит");
@@ -96,7 +96,7 @@ class SegmentationRuleTest {
     }
 
     /** Проверяем возврат привязанной очереди, если правило не определено. */
-    @DisplayName("Returns Linked Queue When No Rules")
+    @DisplayName("При отсутствии правил используется связанная очередь")
     @Test
     void returnsLinkedQueueWhenNoRules() throws SystemException {
         LOG.info("Шаг 1: формируем отделение с единственной очередью");
@@ -114,7 +114,7 @@ class SegmentationRuleTest {
     }
 
     /** Проверяем выполнение groovy-правила. */
-    @DisplayName("Get Queue By Id Executes Groovy Rule")
+    @DisplayName("Метод `getQueueById` выполняет groovy-правило")
     @Test
     void getQueueByIdExecutesGroovyRule() {
         LOG.info("Шаг 1: настраиваем groovy-скрипт для возврата очереди");
@@ -150,7 +150,7 @@ class SegmentationRuleTest {
     }
 
     /** Проверяем пустой идентификатор groovy-правила. */
-    @DisplayName("Get Queue By Id Returns Empty When Id Null Or Empty")
+    @DisplayName("Метод `getQueueById` возвращает пустой результат без идентификатора")
     @Test
     void getQueueByIdReturnsEmptyWhenIdNullOrEmpty() {
         LOG.info("Шаг 1: подготавливаем визит без идентификатора правила");
@@ -166,7 +166,7 @@ class SegmentationRuleTest {
     }
 
     /** Проверяем выброс ошибки при отсутствии входных параметров для groovy. */
-    @DisplayName("Get Queue By Id Throws When Input Params Missing")
+    @DisplayName("Метод `getQueueById` выбрасывает исключение при отсутствии параметров")
     @Test
     void getQueueByIdThrowsWhenInputParamsMissing() {
         LOG.info("Шаг 1: формируем groovy-правило без необходимых параметров");
@@ -194,7 +194,7 @@ class SegmentationRuleTest {
     }
 
     /** Проверяем, что ошибки внутренних вызовов оборачиваются в {@link SystemException}. */
-    @DisplayName("Get Queue Wraps Business Exception Into System Exception")
+    @DisplayName("Метод `getQueue` оборачивает бизнес-исключение в системное")
     @Test
     void getQueueWrapsBusinessExceptionIntoSystemException() {
         LOG.info("Шаг 1: готовим отделение с сервисной группой и отсутствующим правилом");
@@ -214,7 +214,7 @@ class SegmentationRuleTest {
     }
 
     /** Проверяем возврат пустого результата, когда очередь не найдена. */
-    @DisplayName("Returns Empty When Linked Queue Missing")
+    @DisplayName("Метод `getQueue` возвращает пустой результат при отсутствии связанной очереди")
     @Test
     void returnsEmptyWhenLinkedQueueMissing() throws SystemException {
         LOG.info("Шаг 1: формируем сервисную группу без связанной очереди");

--- a/src/test/unit/java/ru/aritmos/service/rules/client/CallRuleClientTest.java
+++ b/src/test/unit/java/ru/aritmos/service/rules/client/CallRuleClientTest.java
@@ -23,7 +23,7 @@ class CallRuleClientTest {
     /**
      * Клиент отправляет запрос и получает визит.
      */
-    @DisplayName("Call Rule Returns Visit")
+    @DisplayName("Клиент правила вызова возвращает визит")
     @Test
     void callRuleReturnsVisit() {
         Map<String, Object> config = Map.of(


### PR DESCRIPTION
## Summary
- унифицировал формулировки @DisplayName в клиентских и инфраструктурных тестах, сделав их полностью русскоязычными
- обновил описания сценариев VisitService для операций удаления, заметок и выборок, выделив имена методов в backtick
- уточнил названия тестов правил сегментации и максимального вызова, описывая ожидаемые результаты на русском языке

## Testing
- not run (не требовалось)

------
https://chatgpt.com/codex/tasks/task_e_68d62ba5ebfc8328b5b556687f8d57f4