### PR TITLE
Уточнение русских описаний тестовых сценариев

### DIFF
--- a/src/test/unit/java/ru/aritmos/ApplicationTest.java
+++ b/src/test/unit/java/ru/aritmos/ApplicationTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
 class ApplicationTest {
-    @DisplayName("Метод main передаёт аргументы в Micronaut.run")
+    @DisplayName("Точка входа передаёт аргументы запуску Micronaut")
     @Test
     void main() {
         try (MockedStatic<Micronaut> mic = mockStatic(Micronaut.class)) {

--- a/src/test/unit/java/ru/aritmos/api/KeyCloakControllerTest.java
+++ b/src/test/unit/java/ru/aritmos/api/KeyCloakControllerTest.java
@@ -12,7 +12,7 @@ import ru.aritmos.keycloack.service.KeyCloackClient;
 
 class KeyCloakControllerTest {
 
-    @DisplayName("Авторизация передается клиенту Keycloak")
+    @DisplayName("Авторизация передаётся клиенту Keycloak")
     @Test
     void authDelegatesToClient() {
         KeyCloakController controller = new KeyCloakController();
@@ -27,7 +27,7 @@ class KeyCloakControllerTest {
         verify(client).Auth(credentials);
     }
 
-    @DisplayName("Удаление сессии передается клиенту Keycloak")
+    @DisplayName("Удаление сессии передаётся клиенту Keycloak")
     @Test
     void deleteSessionDelegatesToClient() {
         KeyCloakController controller = new KeyCloakController();

--- a/src/test/unit/java/ru/aritmos/clients/ConfigurationClientTest.java
+++ b/src/test/unit/java/ru/aritmos/clients/ConfigurationClientTest.java
@@ -19,7 +19,7 @@ class ConfigurationClientTest {
         assertEquals("${micronaut.application.configurationURL}", annotation.value());
     }
 
-    @DisplayName("Метод получения конфигурации помечен аннотацией GET")
+    @DisplayName("Метод получения конфигурации объявлен с HTTP-методом GET")
     @Test
     void getConfigurationMethodHasGetAnnotation() throws NoSuchMethodException {
         Method method = ConfigurationClient.class.getMethod("getConfiguration");

--- a/src/test/unit/java/ru/aritmos/config/LocalNoDockerDataBusClientStubTest.java
+++ b/src/test/unit/java/ru/aritmos/config/LocalNoDockerDataBusClientStubTest.java
@@ -9,7 +9,7 @@ import reactor.core.publisher.Mono;
 
 class LocalNoDockerDataBusClientStubTest {
 
-    @DisplayName("Метод send возвращает заглушенные статус и тип")
+    @DisplayName("Заглушка отправки возвращает предопределённые статус и тип")
     @Test
     void sendReturnsStubbedStatusAndType() {
         LocalNoDockerDataBusClientStub client = new LocalNoDockerDataBusClientStub();

--- a/src/test/unit/java/ru/aritmos/exceptions/BusinessExceptionLocalizationTest.java
+++ b/src/test/unit/java/ru/aritmos/exceptions/BusinessExceptionLocalizationTest.java
@@ -83,7 +83,7 @@ class BusinessExceptionLocalizationTest {
         assertEquals("Visit not found", appender.list.get(0).getFormattedMessage());
     }
 
-    @DisplayName("Заменяет поле «message» в теле ответа типа Map")
+    @DisplayName("Заменяет поле «message» в теле ответа, представленном картой")
     @Test
     void replacesMessageFieldInMapResponseBody() {
         BusinessExceptionLocalizationProperties properties = new BusinessExceptionLocalizationProperties();

--- a/src/test/unit/java/ru/aritmos/keycloack/service/KeyCloackClientTest.java
+++ b/src/test/unit/java/ru/aritmos/keycloack/service/KeyCloackClientTest.java
@@ -33,7 +33,7 @@ class KeyCloackClientTest {
         assertEquals("/r/b", path);
     }
 
-    @DisplayName("Поиск пути отделения по префиксу возвращает null при отсутствии отделения")
+    @DisplayName("Поиск пути отделения по префиксу возвращает пустой результат при отсутствии отделения")
     @Test
     void getBranchPathByBranchPrefixReturnsNullWhenNotFound() {
         KeyCloackClient client = spy(new KeyCloackClient());

--- a/src/test/unit/java/ru/aritmos/model/BasedServiceTest.java
+++ b/src/test/unit/java/ru/aritmos/model/BasedServiceTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 
 class BasedServiceTest {
 
-    @DisplayName("Метод clone создаёт независимую копию исхода")
+    @DisplayName("Клонирование базового сервиса создаёт независимую копию")
     @Test
     void cloneShouldCloneOutcomeIndependently() {
         Outcome outcome = new Outcome("1", "name");

--- a/src/test/unit/java/ru/aritmos/model/BranchEntityTest.java
+++ b/src/test/unit/java/ru/aritmos/model/BranchEntityTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 
 class BranchEntityTest {
 
-    @DisplayName("Метод clone копирует базовые поля")
+    @DisplayName("Клонирование сущности копирует базовые поля")
     @Test
     void cloneShouldCopyBasicFields() {
         BranchEntity entity = new BranchEntity("id", "name");

--- a/src/test/unit/java/ru/aritmos/model/DeliveredServiceTest.java
+++ b/src/test/unit/java/ru/aritmos/model/DeliveredServiceTest.java
@@ -5,7 +5,7 @@ import static ru.aritmos.test.LoggingAssertions.*;
 import org.junit.jupiter.api.DisplayName;
 
 class DeliveredServiceTest {
-    @DisplayName("Метод clone возвращает независимую копию")
+    @DisplayName("Клонирование услуги возвращает независимую копию")
     @Test
     void cloneCreatesIndependentCopy() {
         Outcome outcome = new Outcome("o1", "outcome");

--- a/src/test/unit/java/ru/aritmos/model/EntityTest.java
+++ b/src/test/unit/java/ru/aritmos/model/EntityTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 class EntityTest {
 
     @Test
-    @DisplayName("билдер создает сущность с указанными значениями")
+    @DisplayName("Билдер создаёт сущность с указанными значениями")
     void builderCreatesEntity() {
         Entity entity = Entity.builder()
                 .id("123")
@@ -21,7 +21,7 @@ class EntityTest {
     }
 
     @Test
-    @DisplayName("геттеры, сеттеры и equals/hashCode работают корректно")
+    @DisplayName("Геттеры, сеттеры и методы equals/hashCode работают корректно")
     void gettersSettersAndEqualityWorkCorrectly() {
         Entity первый = new Entity();
         первый.setId("id-1");
@@ -37,7 +37,7 @@ class EntityTest {
     }
 
     @Test
-    @DisplayName("класс Entity аннотирован Serdeable")
+    @DisplayName("Класс Entity аннотирован аннотацией @Serdeable")
     void verifySerdeableAnnotation() {
         assertTrue(Entity.class.isAnnotationPresent(Serdeable.class));
     }

--- a/src/test/unit/java/ru/aritmos/model/EntryPointTest.java
+++ b/src/test/unit/java/ru/aritmos/model/EntryPointTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 
 class EntryPointTest {
 
-    @DisplayName("Наследует поля BranchEntity")
+    @DisplayName("Наследует поля базовой сущности отделения")
     @Test
     void shouldInheritBranchEntityFields() {
         EntryPoint entryPoint = new EntryPoint();

--- a/src/test/unit/java/ru/aritmos/model/GroovyScriptTest.java
+++ b/src/test/unit/java/ru/aritmos/model/GroovyScriptTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test;
 class GroovyScriptTest {
 
     @Test
-    @DisplayName("по умолчанию билдер создает пустые изменяемые карты входных и выходных параметров")
+    @DisplayName("По умолчанию билдер создаёт пустые изменяемые карты входных и выходных параметров")
     void builderCreatesEmptyMapsByDefault() {
         GroovyScript script = GroovyScript.builder().build();
 
@@ -30,7 +30,7 @@ class GroovyScriptTest {
     }
 
     @Test
-    @DisplayName("билдер позволяет задать код правила и собственные параметры")
+    @DisplayName("Билдер позволяет задать код правила и собственные параметры")
     void builderSupportsPopulatingData() {
         HashMap<Object, Object> output = new HashMap<>();
         output.put("result", "готово");
@@ -47,7 +47,7 @@ class GroovyScriptTest {
     }
 
     @Test
-    @DisplayName("модель GroovyScript помечена Serdeable и использует JsonInclude.ALWAYS для карт")
+    @DisplayName("Класс GroovyScript помечен @Serdeable и использует JsonInclude.ALWAYS для карт")
     void verifiesAnnotations() throws NoSuchFieldException {
         assertTrue(GroovyScript.class.isAnnotationPresent(Serdeable.class));
 

--- a/src/test/unit/java/ru/aritmos/model/OutcomeTest.java
+++ b/src/test/unit/java/ru/aritmos/model/OutcomeTest.java
@@ -5,7 +5,7 @@ import static ru.aritmos.test.LoggingAssertions.*;
 import org.junit.jupiter.api.DisplayName;
 
 class OutcomeTest {
-    @DisplayName("Метод clone возвращает независимую копию исхода")
+    @DisplayName("Клонирование исхода возвращает независимую копию")
     @Test
     void cloneCreatesIndependentCopy() {
         Outcome original = new Outcome("1", "name");

--- a/src/test/unit/java/ru/aritmos/model/QueueTest.java
+++ b/src/test/unit/java/ru/aritmos/model/QueueTest.java
@@ -10,11 +10,11 @@ import org.junit.jupiter.api.Test;
  */
 class QueueTest {
 
-    @DisplayName("Конструктор без идентификатора создаёт id и заполняет поля")
+    @DisplayName("Конструктор без идентификатора генерирует значение и заполняет поля")
     @Test
     void constructorGeneratesIdAndSetsFields() {
         Queue queue = new Queue("Main", "A", 60);
-        assertNotNull(queue.getId(), "id should be generated");
+        assertNotNull(queue.getId(), "Идентификатор должен быть сгенерирован");
         assertEquals("Main", queue.getName());
         assertEquals("A", queue.getTicketPrefix());
         assertEquals(60, queue.getWaitingSL());

--- a/src/test/unit/java/ru/aritmos/model/ServiceTest.java
+++ b/src/test/unit/java/ru/aritmos/model/ServiceTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 
 class ServiceTest {
 
-    @DisplayName("Метод clone копирует поля и карты независимо")
+    @DisplayName("Клонирование сервиса создаёт независимые копии полей и карт")
     @Test
     void cloneShouldCopyFieldsAndMapsIndependently() {
         Outcome outcome = new Outcome("1", "outcome");

--- a/src/test/unit/java/ru/aritmos/model/UserInfoTest.java
+++ b/src/test/unit/java/ru/aritmos/model/UserInfoTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 
 class UserInfoTest {
 
-    @DisplayName("Builder и сеттеры формируют одинаковый результат")
+    @DisplayName("Построитель и сеттеры формируют одинаковый результат")
     @Test
     void builderAndSettersBehaveTheSame() {
         RealmAccess access = RealmAccess.builder()

--- a/src/test/unit/java/ru/aritmos/model/UserTokenTest.java
+++ b/src/test/unit/java/ru/aritmos/model/UserTokenTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 
 class UserTokenTest {
 
-    @DisplayName("Builder и сеттеры создают токен пользователя")
+    @DisplayName("Построитель и сеттеры создают токен пользователя")
     @Test
     void builderAndSettersCreateUserToken() {
         UserInfo info = UserInfo.builder()

--- a/src/test/unit/java/ru/aritmos/model/keycloak/RealmAccessTest.java
+++ b/src/test/unit/java/ru/aritmos/model/keycloak/RealmAccessTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 
 class RealmAccessTest {
 
-    @DisplayName("Builder и сеттеры формируют список ролей")
+    @DisplayName("Построитель и сеттеры формируют список ролей")
     @Test
     void builderAndSettersFormRoleList() {
         RealmAccess viaBuilder = RealmAccess.builder()

--- a/src/test/unit/java/ru/aritmos/model/keycloak/TokenTest.java
+++ b/src/test/unit/java/ru/aritmos/model/keycloak/TokenTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 
 class TokenTest {
 
-    @DisplayName("Builder и сеттеры заполняют поля токена")
+    @DisplayName("Построитель и сеттеры заполняют поля токена")
     @Test
     void builderAndSettersPopulateTokenFields() {
         Token viaBuilder = Token.builder()

--- a/src/test/unit/java/ru/aritmos/model/keycloak/UserInfoTest.java
+++ b/src/test/unit/java/ru/aritmos/model/keycloak/UserInfoTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 
 class UserInfoTest {
 
-    @DisplayName("Builder и сеттеры заполняют все поля")
+    @DisplayName("Построитель и сеттеры заполняют все поля")
     @Test
     void builderAndSettersSupportAllFields() {
         RealmAccess realmAccess = RealmAccess.builder()

--- a/src/test/unit/java/ru/aritmos/model/keycloak/UserSessionTest.java
+++ b/src/test/unit/java/ru/aritmos/model/keycloak/UserSessionTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 
 class UserSessionTest {
 
-    @DisplayName("Builder и сеттеры формируют полную сессию")
+    @DisplayName("Построитель и сеттеры формируют полную сессию")
     @Test
     void builderAndSettersCreateCompleteSession() {
         UserToken token = UserToken.builder()

--- a/src/test/unit/java/ru/aritmos/model/keycloak/UserTokenTest.java
+++ b/src/test/unit/java/ru/aritmos/model/keycloak/UserTokenTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 
 class UserTokenTest {
 
-    @DisplayName("Builder и сеттеры формируют объект токена")
+    @DisplayName("Построитель и сеттеры формируют объект токена")
     @Test
     void builderAndSettersConstructObject() {
         UserInfo info = UserInfo.builder()

--- a/src/test/unit/java/ru/aritmos/model/visit/TransactionCompletionStatusTest.java
+++ b/src/test/unit/java/ru/aritmos/model/visit/TransactionCompletionStatusTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 class TransactionCompletionStatusTest {
 
     @Test
-    @DisplayName("перечисление содержит полный список статусов транзакции")
+    @DisplayName("Перечисление содержит полный список статусов транзакции")
     void verifyFullSetOfStatuses() {
         TransactionCompletionStatus[] ожидаемыеСтатусы = {
             TransactionCompletionStatus.OK,
@@ -29,7 +29,7 @@ class TransactionCompletionStatusTest {
     }
 
     @Test
-    @DisplayName("можно получить статус по его строковому имени")
+    @DisplayName("Статус можно получить по его строковому имени")
     void retrievesStatusByName() {
         assertEquals(
             TransactionCompletionStatus.REMOVED_BY_EMP,
@@ -37,7 +37,7 @@ class TransactionCompletionStatusTest {
     }
 
     @Test
-    @DisplayName("перечисление помечено аннотацией Serdeable")
+    @DisplayName("Перечисление помечено аннотацией @Serdeable")
     void verifySerdeableAnnotation() {
         assertTrue(TransactionCompletionStatus.class.isAnnotationPresent(Serdeable.class));
     }

--- a/src/test/unit/java/ru/aritmos/model/visit/VisitEventTest.java
+++ b/src/test/unit/java/ru/aritmos/model/visit/VisitEventTest.java
@@ -27,14 +27,14 @@ class VisitEventTest {
         assertFalse(VisitEvent.isIgnoredInStat(VisitEvent.CREATED));
     }
 
-    @DisplayName("Метод getStatus возвращает корректный статус события")
+    @DisplayName("Получение статуса возвращает ожидаемое значение события")
     @Test
     void testGetStatus() {
         assertEquals(TransactionCompletionStatus.STOP_SERVING, VisitEvent.getStatus(VisitEvent.STOP_SERVING));
         assertNull(VisitEvent.getStatus(VisitEvent.CREATED));
     }
 
-    @DisplayName("Метод canBeNext определяет допустимость следующего события")
+    @DisplayName("Проверка допустимости следующего события возвращает корректный результат")
     @Test
     void testCanBeNext() {
         VisitEvent current = VisitEvent.CREATED;
@@ -47,7 +47,7 @@ class VisitEventTest {
         assertFalse(current.canBeNext(nextForbidden));
     }
 
-    @DisplayName("Метод getState возвращает состояние события")
+    @DisplayName("Получение состояния возвращает ожидаемое значение события")
     @Test
     void testGetState() {
         assertEquals(VisitState.CREATED, VisitEvent.CREATED.getState());

--- a/src/test/unit/java/ru/aritmos/model/visit/VisitStateTest.java
+++ b/src/test/unit/java/ru/aritmos/model/visit/VisitStateTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 class VisitStateTest {
 
     @Test
-    @DisplayName("перечисление содержит последовательность состояний визита")
+    @DisplayName("Перечисление содержит последовательность состояний визита")
     void verifyListOfStates() {
         VisitState[] ожидаемыеСостояния = {
             VisitState.CREATED,
@@ -24,13 +24,13 @@ class VisitStateTest {
     }
 
     @Test
-    @DisplayName("можно получить состояние по его имени")
+    @DisplayName("Состояние можно получить по его имени")
     void retrievesStateByName() {
         assertEquals(VisitState.WAITING_IN_QUEUE, VisitState.valueOf("WAITING_IN_QUEUE"));
     }
 
     @Test
-    @DisplayName("перечисление VisitState также аннотировано Serdeable")
+    @DisplayName("Перечисление состояний визита аннотировано @Serdeable")
     void verifySerdeableAnnotation() {
         assertTrue(VisitState.class.isAnnotationPresent(Serdeable.class));
     }

--- a/src/test/unit/java/ru/aritmos/model/visit/VisitTest.java
+++ b/src/test/unit/java/ru/aritmos/model/visit/VisitTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 
 class VisitTest {
 
-    @DisplayName("Метод getWaitingTime рассчитывает продолжительность ожидания")
+    @DisplayName("Расчёт времени ожидания возвращает продолжительность в миллисекундах")
     @Test
     void getWaitingTimeCalculatesDifference() {
         ZonedDateTime start = ZonedDateTime.now();
@@ -22,7 +22,7 @@ class VisitTest {
         assertEquals(10L, visit.getWaitingTime());
     }
 
-    @DisplayName("Метод getReturningTime использует время возврата")
+    @DisplayName("Расчёт времени возврата учитывает сохранённое значение")
     @Test
     void getReturningTimeUsesReturnDateTime() {
         ZonedDateTime returnTime = ZonedDateTime.now().minusSeconds(5);
@@ -32,14 +32,14 @@ class VisitTest {
         assertTrue(Math.abs(actual - expected) <= 1);
     }
 
-    @DisplayName("Метод getReturningTime возвращает ноль при отсутствии времени возврата")
+    @DisplayName("При отсутствии отметки возврата расчёт времени возвращает ноль")
     @Test
     void getReturningTimeReturnsZeroWhenNull() {
         Visit visit = Visit.builder().build();
         assertEquals(0L, visit.getReturningTime());
     }
 
-    @DisplayName("Метод getTransferingTime использует время перевода")
+    @DisplayName("Расчёт времени перевода использует сохранённую отметку")
     @Test
     void getTransferingTimeUsesTransferDateTime() {
         ZonedDateTime transferTime = ZonedDateTime.now().minusSeconds(7);
@@ -49,7 +49,7 @@ class VisitTest {
         assertTrue(Math.abs(actual - expected) <= 1);
     }
 
-    @DisplayName("Метод getVisitLifeTime рассчитывает длительность визита")
+    @DisplayName("Расчёт длительности визита использует время создания и завершения")
     @Test
     void getVisitLifeTimeCalculatesDifference() {
         ZonedDateTime start = ZonedDateTime.now();
@@ -61,7 +61,7 @@ class VisitTest {
         assertEquals(20L, visit.getVisitLifeTime());
     }
 
-    @DisplayName("Метод getServingTime рассчитывает время обслуживания")
+    @DisplayName("Расчёт времени обслуживания учитывает время начала и окончания")
     @Test
     void getServingTimeCalculatesDifference() {
         ZonedDateTime start = ZonedDateTime.now();

--- a/src/test/unit/java/ru/aritmos/service/VisitServiceCreateVisit2FromReceptionTest.java
+++ b/src/test/unit/java/ru/aritmos/service/VisitServiceCreateVisit2FromReceptionTest.java
@@ -33,7 +33,7 @@ import ru.aritmos.test.TestLoggingExtension;
 @ExtendWith(TestLoggingExtension.class)
 class VisitServiceCreateVisit2FromReceptionTest {
 
-    @DisplayName("createVisit2FromReception с правилом сегментации создаёт визит и печатает талон")
+    @DisplayName("Создание визита из приёмной с правилом сегментации печатает талон")
     @Test
     void createsVisitWithSegmentationRuleAndPrintsTicket() {
         VisitService service = new VisitService();
@@ -141,7 +141,7 @@ class VisitServiceCreateVisit2FromReceptionTest {
         verifyNoMoreInteractions(printerService);
     }
 
-    @DisplayName("createVisit2FromReception возвращает 400, если правило сегментации не подобрало очередь")
+    @DisplayName("Создание визита из приёмной возвращает 400, если правило сегментации не нашло очередь")
     @Test
     void throwsBadRequestWhenSegmentationRuleReturnsEmptyQueue() {
         VisitService service = new VisitService();
@@ -201,7 +201,7 @@ class VisitServiceCreateVisit2FromReceptionTest {
         verify(service.printerService, never()).print(anyString(), any());
     }
 
-    @DisplayName("createVisit2FromReception возвращает 404 при отсутствии очереди в конфигурации отделения")
+    @DisplayName("Создание визита из приёмной возвращает 404, когда очередь отсутствует в конфигурации отделения")
     @Test
     void throwsNotFoundWhenQueueMissingInBranchConfiguration() {
         VisitService service = new VisitService();

--- a/src/test/unit/java/ru/aritmos/service/VisitServiceDeleteVisitTest.java
+++ b/src/test/unit/java/ru/aritmos/service/VisitServiceDeleteVisitTest.java
@@ -37,7 +37,7 @@ class VisitServiceDeleteVisitTest {
         resetVisitEvent();
     }
 
-    @DisplayName("deleteVisit очищает привязки визита и уведомляет отделение")
+    @DisplayName("Удаление визита очищает привязки и уведомляет отделение")
     @Test
     void deleteVisitClearsAssignmentsAndNotifiesBranch() {
         LOG.info("Шаг 1: создаём визит с привязкой к очереди и точке обслуживания");
@@ -70,7 +70,7 @@ class VisitServiceDeleteVisitTest {
         verifyNoInteractions(service.eventService);
     }
 
-    @DisplayName("deleteVisit выбрасывает исключение, если задержка возврата не истекла")
+    @DisplayName("Удаление визита запрещено до истечения задержки возврата")
     @Test
     void deleteVisitThrowsWhenReturnDelayNotElapsed() {
         LOG.info("Шаг 1: готовим визит, недавно вернувшийся в очередь");
@@ -100,7 +100,7 @@ class VisitServiceDeleteVisitTest {
         assertEquals("sp-1", visit.getServicePointId());
     }
 
-    @DisplayName("deleteVisit выбрасывает исключение, если задержка перевода не истекла")
+    @DisplayName("Удаление визита запрещено до истечения задержки перевода")
     @Test
     void deleteVisitThrowsWhenTransferDelayNotElapsed() {
         LOG.info("Шаг 1: формируем визит, недавно переведённый из очереди");

--- a/src/test/unit/java/ru/aritmos/service/VisitServiceDeliveredServicesTest.java
+++ b/src/test/unit/java/ru/aritmos/service/VisitServiceDeliveredServicesTest.java
@@ -23,7 +23,7 @@ import ru.aritmos.model.visit.VisitEvent;
  */
 class VisitServiceDeliveredServicesTest {
 
-    @DisplayName("getDeliveredServices возвращает фактические услуги текущей услуги визита")
+    @DisplayName("Получение фактических услуг возвращает записи текущей услуги визита")
     @Test
     void returnsDeliveredServicesOfCurrentService() {
         VisitService service = new VisitService();
@@ -56,7 +56,7 @@ class VisitServiceDeliveredServicesTest {
         assertSame(delivered, result.get("ds1"));
     }
 
-    @DisplayName("getDeliveredServices выбрасывает исключение при отсутствии текущей услуги")
+    @DisplayName("Получение фактических услуг выбрасывает исключение при отсутствии текущей услуги")
     @Test
     void throwsWhenCurrentServiceMissing() {
         VisitService service = new VisitService();
@@ -78,7 +78,7 @@ class VisitServiceDeliveredServicesTest {
         verify(eventService).send(eq("*"), eq(false), any());
     }
 
-    @DisplayName("addDeliveredService добавляет фактическую услугу к текущей услуге")
+    @DisplayName("Добавление фактической услуги прикрепляет запись к текущей услуге визита")
     @Test
     void addDeliveredServiceAddsToCurrentService() {
         Branch branch = new Branch("b1", "Branch");
@@ -110,7 +110,7 @@ class VisitServiceDeliveredServicesTest {
         verify(branchService).updateVisit(eq(visit), any(VisitEvent.class), eq(service));
     }
 
-    @DisplayName("deleteDeliveredService удаляет фактическую услугу из текущей услуги")
+    @DisplayName("Удаление фактической услуги удаляет запись из текущей услуги визита")
     @Test
     void deleteDeliveredServiceRemovesFromCurrentService() {
         Branch branch = new Branch("b1", "Branch");
@@ -142,7 +142,7 @@ class VisitServiceDeliveredServicesTest {
     }
 
 
-    @DisplayName("addOutcomeOfDeliveredService устанавливает исход фактической услуги")
+    @DisplayName("Установка исхода фактической услуги фиксирует результат обслуживания")
     @Test
     void addOutcomeOfDeliveredServiceSetsOutcome() {
         Branch branch = new Branch("b1", "Branch");
@@ -174,7 +174,7 @@ class VisitServiceDeliveredServicesTest {
         verify(branchService).updateVisit(eq(visit), any(VisitEvent.class), eq(service));
     }
 
-    @DisplayName("addOutcomeOfDeliveredService выбрасывает исключение при отсутствии фактической услуги")
+    @DisplayName("Установка исхода фактической услуги выбрасывает исключение при отсутствии записи")
     @Test
     void addOutcomeOfDeliveredServiceThrowsWhenMissingDeliveredService() {
         Branch branch = new Branch("b1", "Branch");
@@ -201,7 +201,7 @@ class VisitServiceDeliveredServicesTest {
         verify(eventService).send(eq("*"), eq(false), any());
     }
 
-    @DisplayName("deleteOutcomeDeliveredService очищает исход фактической услуги")
+    @DisplayName("Удаление исхода фактической услуги очищает результат обслуживания")
     @Test
     void deleteOutcomeDeliveredServiceClearsOutcome() {
         Branch branch = new Branch("b1", "Branch");

--- a/src/test/unit/java/ru/aritmos/service/VisitServiceGetMarksTest.java
+++ b/src/test/unit/java/ru/aritmos/service/VisitServiceGetMarksTest.java
@@ -21,7 +21,7 @@ import ru.aritmos.model.visit.Visit;
  */
 class VisitServiceGetMarksTest {
 
-    @DisplayName("getMarks возвращает метки визита")
+    @DisplayName("Получение меток возвращает список заметок визита")
     @Test
     void returnsMarksOfVisit() {
         Branch branch = new Branch("b1", "Branch");
@@ -50,7 +50,7 @@ class VisitServiceGetMarksTest {
         assertSame(mark, marks.get(0));
     }
 
-    @DisplayName("getMarks выбрасывает исключение при отсутствии визита")
+    @DisplayName("Получение меток выбрасывает исключение при отсутствии визита")
     @Test
     void throwsWhenVisitMissing() {
         Branch branch = new Branch("b1", "Branch");

--- a/src/test/unit/java/ru/aritmos/service/VisitServiceGetVisitsTest.java
+++ b/src/test/unit/java/ru/aritmos/service/VisitServiceGetVisitsTest.java
@@ -22,7 +22,7 @@ import ru.aritmos.model.visit.Visit;
 class VisitServiceGetVisitsTest {
 
     /** Проверяет фильтрацию визитов и сортировку по времени ожидания. */
-    @DisplayName("getVisits фильтрует и сортирует визиты")
+    @DisplayName("Получение визитов фильтрует и сортирует результаты")
     @Test
     void filtersAndSortsVisits() {
         VisitService service = new VisitService();
@@ -58,7 +58,7 @@ class VisitServiceGetVisitsTest {
     }
 
     /** Проверяет фильтрацию по ограничению времени перевода визита. */
-    @DisplayName("getVisits учитывает ограничение по времени перевода")
+    @DisplayName("Получение визитов учитывает ограничение по времени перевода")
     @Test
     void filtersVisitsByTransferDelay() {
         VisitService service = new VisitService();
@@ -97,7 +97,7 @@ class VisitServiceGetVisitsTest {
     }
 
     /** Ограничивает количество возвращаемых визитов. */
-    @DisplayName("getVisits ограничивает количество возвращаемых визитов")
+    @DisplayName("Получение визитов ограничивает количество результатов")
     @Test
     void limitsNumberOfVisits() {
         VisitService service = new VisitService();
@@ -123,7 +123,7 @@ class VisitServiceGetVisitsTest {
     }
 
     /** Бросает HTTP-исключение, если очередь не найдена. */
-    @DisplayName("getVisits выбрасывает исключение при отсутствии очереди")
+    @DisplayName("Получение визитов выбрасывает исключение при отсутствии очереди")
     @Test
     void throwsWhenQueueMissing() {
         VisitService service = new VisitService();

--- a/src/test/unit/java/ru/aritmos/service/VisitServiceMarkLookupByIdTest.java
+++ b/src/test/unit/java/ru/aritmos/service/VisitServiceMarkLookupByIdTest.java
@@ -26,7 +26,7 @@ class VisitServiceMarkLookupByIdTest {
 
     private static final Logger LOG = LoggerFactory.getLogger(VisitServiceMarkLookupByIdTest.class);
 
-    @DisplayName("addMark по идентификатору делегирует существующей отметке")
+    @DisplayName("Добавление отметки по идентификатору делегирует существующей записи")
     @Test
     void addMarkByIdDelegatesToExistingMark() {
         LOG.info("Шаг 1: создаём отделение с преднастроенной заметкой");
@@ -56,7 +56,7 @@ class VisitServiceMarkLookupByIdTest {
         verifyNoInteractions(eventService);
     }
 
-    @DisplayName("addMark по идентификатору выбрасывает исключение при отсутствии отметки")
+    @DisplayName("Добавление отметки по идентификатору выбрасывает исключение при отсутствии записи")
     @Test
     void addMarkByIdThrowsWhenMarkMissing() {
         LOG.info("Шаг 1: создаём отделение без требуемой заметки");
@@ -79,7 +79,7 @@ class VisitServiceMarkLookupByIdTest {
         verify(eventService).send(eq("*"), eq(false), any());
     }
 
-    @DisplayName("deleteMark по идентификатору делегирует существующей отметке")
+    @DisplayName("Удаление отметки по идентификатору делегирует существующей записи")
     @Test
     void deleteMarkByIdDelegatesToExistingMark() {
         LOG.info("Шаг 1: создаём отделение с заметкой для удаления");
@@ -109,7 +109,7 @@ class VisitServiceMarkLookupByIdTest {
         verifyNoInteractions(eventService);
     }
 
-    @DisplayName("deleteMark по идентификатору выбрасывает исключение при отсутствии отметки")
+    @DisplayName("Удаление отметки по идентификатору выбрасывает исключение при отсутствии записи")
     @Test
     void deleteMarkByIdThrowsWhenMarkMissing() {
         LOG.info("Шаг 1: подготавливаем отделение без искомой заметки");

--- a/src/test/unit/java/ru/aritmos/service/VisitServiceMaxCallRulesTest.java
+++ b/src/test/unit/java/ru/aritmos/service/VisitServiceMaxCallRulesTest.java
@@ -31,7 +31,7 @@ import ru.aritmos.test.TestLoggingExtension;
 @ExtendWith(TestLoggingExtension.class)
 class VisitServiceMaxCallRulesTest {
 
-    @DisplayName("visitCallWithMaximalWaitingTime использует результат правила")
+    @DisplayName("Стратегия вызова с максимальным ожиданием использует результат правила")
     @Test
     void visitCallWithMaximalWaitingTimeUsesRuleResult() {
         log.info("Готовим отделение и точку обслуживания с оператором для сценария максимального ожидания");
@@ -88,7 +88,7 @@ class VisitServiceMaxCallRulesTest {
         verify(service, times(2)).visitCall(eq(branch.getId()), eq(servicePoint.getId()), any(Visit.class), eq("callNext"));
     }
 
-    @DisplayName("visitCallWithMaximalWaitingTime включает автообзвон при пустом ответе правила")
+    @DisplayName("Стратегия вызова с максимальным ожиданием включает автообзвон при пустом ответе правила")
     @Test
     void visitCallWithMaximalWaitingTimeEnablesAutocallWhenRuleReturnsEmpty() {
         log.info("Настраиваем отделение в режиме авто-вызова для проверки перехода в автодовызов");
@@ -143,7 +143,7 @@ class VisitServiceMaxCallRulesTest {
         verify(branchService, times(2)).add(branch.getId(), branch);
     }
 
-    @DisplayName("visitCallWithMaximalWaitingTime возвращает 404 при отсутствии точки обслуживания")
+    @DisplayName("Стратегия вызова с максимальным ожиданием возвращает 404 при отсутствии точки обслуживания")
     @Test
     void visitCallWithMaximalWaitingTimeFailsWhenServicePointMissing() {
         log.info("Проверяем сценарий, когда точка обслуживания отсутствует в конфигурации отделения");
@@ -168,7 +168,7 @@ class VisitServiceMaxCallRulesTest {
         assertEquals(HttpStatus.NOT_FOUND, second.getStatus());
     }
 
-    @DisplayName("visitCallWithMaxLifeTime возвращает 404 при отсутствии точки обслуживания")
+    @DisplayName("Стратегия вызова с ограничением по времени возвращает 404 при отсутствии точки обслуживания")
     @Test
     void visitCallWithMaxLifeTimeFailsWhenServicePointMissing() {
         log.info("Конфигурация отделения не содержит точку обслуживания, ожидаем ошибку при вызове по времени жизни");
@@ -193,7 +193,7 @@ class VisitServiceMaxCallRulesTest {
         assertEquals(HttpStatus.NOT_FOUND, second.getStatus());
     }
 
-    @DisplayName("visitCallWithMaximalWaitingTime возвращает 403 при незалогиненном операторе")
+    @DisplayName("Стратегия вызова с максимальным ожиданием возвращает 403 для незалогиненного оператора")
     @Test
     void visitCallWithMaximalWaitingTimeFailsWhenUserNotLogged() {
         log.info("Создаём точку обслуживания без оператора и проверяем реакцию метода");
@@ -220,7 +220,7 @@ class VisitServiceMaxCallRulesTest {
         assertEquals(HttpStatus.FORBIDDEN, second.getStatus());
     }
 
-    @DisplayName("visitCallWithMaxLifeTime возвращает 403 при незалогиненном операторе")
+    @DisplayName("Стратегия вызова с ограничением по времени возвращает 403 для незалогиненного оператора")
     @Test
     void visitCallWithMaxLifeTimeFailsWhenUserNotLogged() {
         log.info("Имитация точки без оператора для правила по времени жизни");
@@ -247,7 +247,7 @@ class VisitServiceMaxCallRulesTest {
         assertEquals(HttpStatus.FORBIDDEN, second.getStatus());
     }
 
-    @DisplayName("visitCallWithMaximalWaitingTime возвращает пусто без автообзвона")
+    @DisplayName("Стратегия вызова с максимальным ожиданием не инициирует автообзвон при запрете")
     @Test
     void visitCallWithMaximalWaitingTimeReturnsEmptyWhenNoAutoCallConfigured() {
         log.info("Готовим отделение без режима автодовызова и ожидаем пустой результат");
@@ -283,7 +283,7 @@ class VisitServiceMaxCallRulesTest {
         verify(eventService, never()).send(anyString(), anyBoolean(), any(Event.class));
     }
 
-    @DisplayName("visitCallWithMaxLifeTime возвращает пусто без автообзвона")
+    @DisplayName("Стратегия вызова с ограничением по времени не инициирует автообзвон при запрете")
     @Test
     void visitCallWithMaxLifeTimeReturnsEmptyWhenNoAutoCallConfigured() {
         log.info("Отделение без автодовызова должно возвращать пустой результат при отсутствии кандидатов по времени жизни");
@@ -319,7 +319,7 @@ class VisitServiceMaxCallRulesTest {
         verify(eventService, never()).send(anyString(), anyBoolean(), any(Event.class));
     }
 
-    @DisplayName("visitCallWithMaxLifeTime использует результат правила")
+    @DisplayName("Стратегия вызова с ограничением по времени использует результат правила")
     @Test
     void visitCallWithMaxLifeTimeUsesRuleResult() {
         log.info("Готовим отделение для сценария вызова по максимальному времени жизни визита");
@@ -376,7 +376,7 @@ class VisitServiceMaxCallRulesTest {
         verify(service, times(2)).visitCall(eq(branch.getId()), eq(servicePoint.getId()), any(Visit.class), eq("callNext"));
     }
 
-    @DisplayName("visitCallWithMaxLifeTime включает автообзвон при пустом ответе правила")
+    @DisplayName("Стратегия вызова с ограничением по времени включает автообзвон при пустом ответе правила")
     @Test
     void visitCallWithMaxLifeTimeEnablesAutocallWhenRuleReturnsEmpty() {
         log.info("Создаём отделение с авто-вызовом для проверки поведения правил по времени жизни");

--- a/src/test/unit/java/ru/aritmos/service/VisitServiceNoteTest.java
+++ b/src/test/unit/java/ru/aritmos/service/VisitServiceNoteTest.java
@@ -20,7 +20,7 @@ import ru.aritmos.model.visit.VisitEvent;
 
 class VisitServiceNoteTest {
 
-    @DisplayName("addNote добавляет запись и инициирует обновление визита")
+    @DisplayName("Добавление заметки инициирует обновление визита")
     @Test
     void addNoteAppendsNoteAndCallsUpdate() {
         Branch branch = new Branch("b1", "Branch");
@@ -53,7 +53,7 @@ class VisitServiceNoteTest {
         verify(branchService).updateVisit(eq(visit), any(VisitEvent.class), eq(serviceBean));
     }
 
-    @DisplayName("addNote выбрасывает исключение при отсутствии визита")
+    @DisplayName("Добавление заметки выбрасывает исключение при отсутствии визита")
     @Test
     void addNoteThrowsWhenNoVisit() {
         Branch branch = new Branch("b1", "Branch");
@@ -72,7 +72,7 @@ class VisitServiceNoteTest {
         verify(eventService).send(eq("*"), eq(false), any());
     }
 
-    @DisplayName("getNotes возвращает заметки визита")
+    @DisplayName("Получение заметок возвращает список заметок визита")
     @Test
     void getNotesReturnsNotes() {
         Branch branch = new Branch("b1", "Branch");
@@ -102,7 +102,7 @@ class VisitServiceNoteTest {
         assertEquals("note", notes.get(0).getValue());
     }
 
-    @DisplayName("getNotes выбрасывает исключение при отсутствии визита")
+    @DisplayName("Получение заметок выбрасывает исключение при отсутствии визита")
     @Test
     void getNotesThrowsWhenVisitMissing() {
         Branch branch = new Branch("b1", "Branch");

--- a/src/test/unit/java/ru/aritmos/service/VisitServiceTest.java
+++ b/src/test/unit/java/ru/aritmos/service/VisitServiceTest.java
@@ -466,7 +466,7 @@ class VisitServiceTest {
         assertTrue(result.containsKey("sp2"));
     }
 
-    @DisplayName("Получение рабочих профилей возвращает Tiny-модели")
+    @DisplayName("Получение рабочих профилей возвращает облегчённые модели")
     @Test
     void getWorkProfilesReturnsTinyClasses() {
         Branch branch = new Branch("b1", "Branch");

--- a/src/test/unit/java/ru/aritmos/service/VisitServiceUncoveredOperationsTest.java
+++ b/src/test/unit/java/ru/aritmos/service/VisitServiceUncoveredOperationsTest.java
@@ -297,7 +297,7 @@ class VisitServiceUncoveredOperationsTest {
         assertEquals(activePoint.getId(), backEvent.getParameters().get("servicePointId"));
     }
 
-    @DisplayName("Перенос визита с объектом Visit ставит запись в начало при соответствующем запросе")
+    @DisplayName("Перенос визита по переданной сущности помещает запись в начало очереди по запросу")
     @Test
     void visitTransferWithVisitEntityPlacesToStartWhenRequested() {
         log.info("Подготавливаем отделение с точкой обслуживания и двумя очередями");

--- a/src/test/unit/java/ru/aritmos/service/VisitServiceVisitCallTest.java
+++ b/src/test/unit/java/ru/aritmos/service/VisitServiceVisitCallTest.java
@@ -185,7 +185,7 @@ class VisitServiceVisitCallTest {
         assertNull(visit.getPoolUserId());
     }
 
-    @DisplayName("Вызов визита по идентификатору делегирует обработчику «cherry-pick» и корректно реагирует на отсутствие визита")
+    @DisplayName("Вызов визита по идентификатору делегирует обработчику точечного выбора и корректно реагирует на отсутствие визита")
     @Test
     void visitCallByIdDelegatesToCherryPickAndHandlesMissing() {
         Visit visit = Visit.builder().id("v1").branchId("b1").parameterMap(new HashMap<>()).build();

--- a/src/test/unit/java/ru/aritmos/service/rules/CallRuleTest.java
+++ b/src/test/unit/java/ru/aritmos/service/rules/CallRuleTest.java
@@ -21,7 +21,7 @@ class CallRuleTest {
         assertTrue(Rule.class.isAssignableFrom(CallRule.class));
     }
 
-    @DisplayName("Метод вызова без фильтра очередей возвращает Optional с визитом")
+    @DisplayName("Метод вызова без фильтра очередей возвращает тип Optional с визитом")
     @Test
     void callMethodWithoutQueueFilterShouldReturnOptionalVisit() throws NoSuchMethodException {
         Method method = CallRule.class.getMethod("call", Branch.class, ServicePoint.class);
@@ -32,7 +32,7 @@ class CallRuleTest {
         assertEquals(Visit.class, elementType);
     }
 
-    @DisplayName("Метод вызова с фильтром очередей возвращает Optional с визитом")
+    @DisplayName("Метод вызова с фильтром очередей возвращает тип Optional с визитом")
     @Test
     void callMethodWithQueueFilterShouldReturnOptionalVisit() throws NoSuchMethodException {
         Method method = CallRule.class.getMethod("call", Branch.class, ServicePoint.class, List.class);

--- a/src/test/unit/java/ru/aritmos/service/rules/CustomCallRuleTest.java
+++ b/src/test/unit/java/ru/aritmos/service/rules/CustomCallRuleTest.java
@@ -19,7 +19,7 @@ import ru.aritmos.service.rules.client.CallRuleClient;
 class CustomCallRuleTest {
 
     /** Проверяет, что вызов делегируется клиенту правил. */
-    @DisplayName("call делегирует выбор визита клиенту правил")
+    @DisplayName("Вызов правила делегирует выбор визита клиенту правил")
     @Test
     void delegatesCallToClient() {
         CallRuleClient client = mock(CallRuleClient.class);
@@ -37,7 +37,7 @@ class CustomCallRuleTest {
     }
 
     /** Метод с идентификаторами очередей пока не реализован. */
-    @DisplayName("call с идентификаторами очередей возвращает пустой результат")
+    @DisplayName("Вызов правила по списку очередей возвращает пустой результат")
     @Test
     void callWithQueueIdsReturnsEmpty() {
         CustomCallRule rule = new CustomCallRule();
@@ -46,7 +46,7 @@ class CustomCallRuleTest {
     }
 
     /** Метод получения доступных точек обслуживания возвращает пустой список. */
-    @DisplayName("getAvailiableServicePoints возвращает пустой список точек")
+    @DisplayName("Определение доступных точек возвращает пустой список")
     @Test
     void getAvailiableServicePointsReturnsEmpty() {
         CustomCallRule rule = new CustomCallRule();

--- a/src/test/unit/java/ru/aritmos/service/rules/MaxWaitingTimeCallRuleTest.java
+++ b/src/test/unit/java/ru/aritmos/service/rules/MaxWaitingTimeCallRuleTest.java
@@ -21,7 +21,7 @@ import ru.aritmos.model.visit.Visit;
 class MaxWaitingTimeCallRuleTest {
 
     /** Проверяем корректный парсинг даты из строки. */
-    @DisplayName("getDateNyString корректно парсит дату из строки")
+    @DisplayName("Метод преобразования строки в дату возвращает корректный результат")
     @Test
     void parseDateFromString() {
         MaxWaitingTimeCallRule rule = new MaxWaitingTimeCallRule();
@@ -35,7 +35,7 @@ class MaxWaitingTimeCallRuleTest {
     /**
      * Проверяем отбор доступных точек обслуживания по рабочему профилю.
      */
-    @DisplayName("getAvailiableServicePoints фильтрует точки по рабочему профилю")
+    @DisplayName("Определение доступных точек учитывает рабочий профиль")
     @Test
     void availableServicePointsFilteredByWorkProfile() {
         // создаем отделение
@@ -86,7 +86,7 @@ class MaxWaitingTimeCallRuleTest {
     /**
      * Проверяем, что при неверном рабочем профиле выбрасывается исключение.
      */
-    @DisplayName("call выбрасывает исключение при неверном рабочем профиле")
+    @DisplayName("Вызов правила генерирует ошибку при неверном рабочем профиле")
     @Test
     void callThrowsWhenWorkProfileIsWrong() {
         MaxWaitingTimeCallRule rule = new MaxWaitingTimeCallRule();
@@ -106,7 +106,7 @@ class MaxWaitingTimeCallRuleTest {
     }
 
     /** Проверяем вызов визита по максимальному ожиданию из списка очередей. */
-    @DisplayName("call с очередями выбирает визит с максимальным ожиданием")
+    @DisplayName("Вызов правила с очередями выбирает визит с максимальным ожиданием")
     @Test
     void callWithQueueIdsSelectsVisit() {
         MaxWaitingTimeCallRule rule = new MaxWaitingTimeCallRule();
@@ -144,7 +144,7 @@ class MaxWaitingTimeCallRuleTest {
     }
 
     /** Проверяем, что без пользователя выбрасывается исключение при вызове с очередями. */
-    @DisplayName("call с очередями выбрасывает исключение без оператора")
+    @DisplayName("Вызов правила с очередями требует назначенного оператора")
     @Test
     void callWithQueueIdsWithoutUserThrows() {
         MaxWaitingTimeCallRule rule = new MaxWaitingTimeCallRule();
@@ -159,7 +159,7 @@ class MaxWaitingTimeCallRuleTest {
     }
 
     /** Проверяем работу компаратора перенесённых визитов. */
-    @DisplayName("visitComparer учитывает флаги переноса визита")
+    @DisplayName("Сравнение визитов учитывает флаги переноса")
     @Test
     void visitComparerHandlesTransferFlags() throws Exception {
         MaxWaitingTimeCallRule rule = new MaxWaitingTimeCallRule();
@@ -183,7 +183,7 @@ class MaxWaitingTimeCallRuleTest {
     }
 
     /** Проверяем выбор визита с максимальным временем ожидания без списка очередей. */
-    @DisplayName("call выбирает визит с наибольшим временем ожидания")
+    @DisplayName("Вызов правила без очередей выбирает визит с наибольшим ожиданием")
     @Test
     void callSelectsVisitWithLongestWaitingTime() {
         MaxWaitingTimeCallRule rule = new MaxWaitingTimeCallRule();
@@ -224,7 +224,7 @@ class MaxWaitingTimeCallRuleTest {
     }
 
     /** Проверяем очистку флагов переноса/возврата после выбора визита. */
-    @DisplayName("call сбрасывает временные флаги переноса у выбранного визита")
+    @DisplayName("Вызов правила сбрасывает временные флаги переноса выбранного визита")
     @Test
     void callResetsTransferFlagsOnSelectedVisit() {
         MaxWaitingTimeCallRule rule = new MaxWaitingTimeCallRule();
@@ -265,7 +265,7 @@ class MaxWaitingTimeCallRuleTest {
     }
 
     /** Проверяем, что при отсутствии пользователя выбрасывается исключение. */
-    @DisplayName("call выбрасывает исключение при отсутствии оператора")
+    @DisplayName("Вызов правила без операторов завершается исключением")
     @Test
     void callThrowsWhenNoUserAssigned() {
         MaxWaitingTimeCallRule rule = new MaxWaitingTimeCallRule();
@@ -282,7 +282,7 @@ class MaxWaitingTimeCallRuleTest {
     }
 
     /** Проверяем, что компаратор учитывает порядок по датам переноса. */
-    @DisplayName("visitComparer отдаёт приоритет более ранней дате переноса")
+    @DisplayName("Сравнение визитов отдаёт приоритет более раннему переносу")
     @Test
     void visitComparerPrefersEarlierTransferDates() throws Exception {
         MaxWaitingTimeCallRule rule = new MaxWaitingTimeCallRule();
@@ -306,7 +306,7 @@ class MaxWaitingTimeCallRuleTest {
     }
 
     /** Проверяем, что визиты без статуса WAITING игнорируются. */
-    @DisplayName("call игнорирует визиты без статуса ожидания")
+    @DisplayName("Вызов правила пропускает визиты вне статуса ожидания")
     @Test
     void callIgnoresVisitsWithoutWaitingStatus() {
         MaxWaitingTimeCallRule rule = new MaxWaitingTimeCallRule();
@@ -337,7 +337,7 @@ class MaxWaitingTimeCallRuleTest {
     }
 
     /** Проверяем, что визиты с ненабранной задержкой возвращения пропускаются. */
-    @DisplayName("call пропускает визиты до истечения задержки возврата")
+    @DisplayName("Вызов правила игнорирует визиты до окончания задержки возврата")
     @Test
     void callSkipsVisitsUntilReturnDelayReached() {
         MaxWaitingTimeCallRule rule = new MaxWaitingTimeCallRule();
@@ -381,7 +381,7 @@ class MaxWaitingTimeCallRuleTest {
     }
 
     /** Проверяем очистку временных полей при выборе визита через список очередей. */
-    @DisplayName("call с очередями сбрасывает временные флаги переноса")
+    @DisplayName("Вызов правила с очередями сбрасывает временные флаги переноса")
     @Test
     void callWithQueueIdsResetsTemporaryFlags() {
         MaxWaitingTimeCallRule rule = new MaxWaitingTimeCallRule();
@@ -421,7 +421,7 @@ class MaxWaitingTimeCallRuleTest {
     }
 
     /** Проверяем, что при выборе по списку очередей визиты с задержкой возвращения не подходят. */
-    @DisplayName("call с очередями возвращает пусто до истечения задержки возврата")
+    @DisplayName("Вызов правила с очередями не возвращает визит до окончания задержки возврата")
     @Test
     void callWithQueueIdsReturnsEmptyWhenReturnDelayNotMet() {
         MaxWaitingTimeCallRule rule = new MaxWaitingTimeCallRule();
@@ -455,7 +455,7 @@ class MaxWaitingTimeCallRuleTest {
     }
 
     /** Проверяем, что без подходящих пользователей список точек обслуживания пуст. */
-    @DisplayName("getAvailiableServicePoints возвращает пусто без активных операторов")
+    @DisplayName("Определение доступных точек возвращает пустой список без активных операторов")
     @Test
     void availableServicePointsReturnEmptyWhenNoActiveUsers() {
         Branch branch = new Branch("b1", "branch");

--- a/src/test/unit/java/ru/aritmos/service/rules/SegmentationRuleTest.java
+++ b/src/test/unit/java/ru/aritmos/service/rules/SegmentationRuleTest.java
@@ -114,7 +114,7 @@ class SegmentationRuleTest {
     }
 
     /** Проверяем выполнение groovy-правила. */
-    @DisplayName("Метод getQueueById выполняет groovy-правило")
+    @DisplayName("Скрипт Groovy для очереди по идентификатору выполняется корректно")
     @Test
     void getQueueByIdExecutesGroovyRule() {
         LOG.info("Шаг 1: настраиваем groovy-скрипт для возврата очереди");
@@ -150,7 +150,7 @@ class SegmentationRuleTest {
     }
 
     /** Проверяем пустой идентификатор groovy-правила. */
-    @DisplayName("Метод getQueueById возвращает пустой результат без идентификатора")
+    @DisplayName("Поиск очереди без идентификатора возвращает пустой результат")
     @Test
     void getQueueByIdReturnsEmptyWhenIdNullOrEmpty() {
         LOG.info("Шаг 1: подготавливаем визит без идентификатора правила");
@@ -166,7 +166,7 @@ class SegmentationRuleTest {
     }
 
     /** Проверяем выброс ошибки при отсутствии входных параметров для groovy. */
-    @DisplayName("Метод getQueueById выбрасывает исключение при отсутствии параметров")
+    @DisplayName("Отсутствие параметров при поиске очереди приводит к исключению")
     @Test
     void getQueueByIdThrowsWhenInputParamsMissing() {
         LOG.info("Шаг 1: формируем groovy-правило без необходимых параметров");
@@ -194,7 +194,7 @@ class SegmentationRuleTest {
     }
 
     /** Проверяем, что ошибки внутренних вызовов оборачиваются в {@link SystemException}. */
-    @DisplayName("Метод getQueue оборачивает бизнес-исключение в системное")
+    @DisplayName("Ошибка бизнес-логики при поиске очереди преобразуется в системное исключение")
     @Test
     void getQueueWrapsBusinessExceptionIntoSystemException() {
         LOG.info("Шаг 1: готовим отделение с сервисной группой и отсутствующим правилом");


### PR DESCRIPTION
## Summary
- Обновлены @DisplayName в тестах моделей Entity, GroovyScript и Queue, избавившись от англицизмов и подчёркнув использование аннотаций.
- Приведены к единому стилю описания сценариев перечислений VisitState и TransactionCompletionStatus с упоминанием @Serdeable.
- Исправлены формулировки в проверках CallRule и VisitService, сохранив русский контекст при ссылках на Optional.

## Testing
- not run (текстовые правки описаний тестов)


------
https://chatgpt.com/codex/tasks/task_e_68d6354932e88328a992226031a80191