### PR TITLE
fix: уточнить формулировки режимов автоматического вызова в тестах

### DIFF
--- a/src/test/unit/java/ru/aritmos/service/VisitServiceAutoCallModeTest.java
+++ b/src/test/unit/java/ru/aritmos/service/VisitServiceAutoCallModeTest.java
@@ -40,7 +40,7 @@ class VisitServiceAutoCallModeTest {
         visitService.setLifeTimeCallRule(mock(CallRule.class));
     }
 
-    @DisplayName("Запуск автодозвона окна включает режим при разрешении на филиале")
+    @DisplayName("Запуск автоматического вызова для окна включает режим при разрешении на филиале")
     @Test
     void startAutoCallModeOfServicePointTurnsOnModeWhenBranchAllows() {
         Branch branch = new Branch("b1", "Branch");
@@ -64,7 +64,7 @@ class VisitServiceAutoCallModeTest {
         assertSame(servicePoint, event.getBody());
     }
 
-    @DisplayName("Запуск автодозвона окна при отключённом филиале завершается конфликтом")
+    @DisplayName("Запуск автоматического вызова для окна при отключённом режиме филиала завершается конфликтом")
     @Test
     void startAutoCallModeOfServicePointThrowsConflictWhenAutoCallDisabled() {
         Branch branch = new Branch("b1", "Branch");
@@ -82,7 +82,7 @@ class VisitServiceAutoCallModeTest {
         verify(branchService, never()).add(anyString(), any(Branch.class));
     }
 
-    @DisplayName("Запуск автодозвона окна при отсутствии окна обслуживания возвращает статус 404")
+    @DisplayName("Запуск автоматического вызова для окна без существующего окна обслуживания возвращает статус 404")
     @Test
     void startAutoCallModeOfServicePointThrowsNotFoundWhenServicePointMissing() {
         Branch branch = new Branch("b1", "Branch");

--- a/src/test/unit/java/ru/aritmos/service/VisitServiceAutoCallTest.java
+++ b/src/test/unit/java/ru/aritmos/service/VisitServiceAutoCallTest.java
@@ -15,7 +15,7 @@ import ru.aritmos.model.ServicePoint;
 
 class VisitServiceAutoCallTest {
 
-    @DisplayName("Отключение автодозвона филиала снимает режим с окон обслуживания")
+    @DisplayName("Отключение режима автоматического вызова на филиале отключает окна обслуживания")
     @Test
     void branchAutoCallModeDisablesServicePoints() {
         Branch branch = new Branch("b1", "Branch");
@@ -38,7 +38,7 @@ class VisitServiceAutoCallTest {
         verify(branchService).add("b1", branch);
     }
 
-    @DisplayName("Включение автодозвона окна проходит успешно при активном автодозвоне филиала")
+    @DisplayName("Включение автоматического вызова для окна проходит успешно при активном режиме филиала")
     @Test
     void servicePointAutoCallModeEnablesWhenBranchModeOn() {
         Branch branch = new Branch("b1", "Branch");
@@ -66,7 +66,7 @@ class VisitServiceAutoCallTest {
         verify(branchService).add("b1", branch);
     }
 
-    @DisplayName("Включение автодозвона окна при выключенном филиале завершается ошибкой")
+    @DisplayName("Включение автоматического вызова для окна при выключенном режиме филиала завершается ошибкой")
     @Test
     void servicePointAutoCallModeFailsWhenBranchModeOff() {
         Branch branch = new Branch("b1", "Branch");
@@ -88,7 +88,7 @@ class VisitServiceAutoCallTest {
         verify(eventService).send(eq("*"), eq(false), any());
     }
 
-    @DisplayName("Включение автодозвона окна при отсутствии окна обслуживания приводит к ошибке")
+    @DisplayName("Попытка включить автоматический вызов для отсутствующего окна обслуживания приводит к ошибке")
     @Test
     void servicePointAutoCallModeThrowsWhenServicePointMissing() {
         Branch branch = new Branch("b1", "Branch");
@@ -108,7 +108,7 @@ class VisitServiceAutoCallTest {
         verify(eventService).send(eq("*"), eq(false), any());
     }
 
-    @DisplayName("Отключение автодозвона окна при выключенном филиале возвращает текущее окно")
+    @DisplayName("Отключение автоматического вызова для окна при выключенном режиме филиала возвращает текущее окно")
     @Test
     void servicePointAutoCallModeReturnsExistingWhenDisablingWithBranchModeOff() {
         Branch branch = new Branch("b1", "Branch");
@@ -134,7 +134,7 @@ class VisitServiceAutoCallTest {
         verifyNoInteractions(eventService);
     }
 
-    @DisplayName("Отмена автодозвона окна отключает режим и публикует событие")
+    @DisplayName("Отмена автоматического вызова для окна отключает режим и публикует событие")
     @Test
     void cancelAutoCallModeDisablesPointAndEmitsEvent() {
         Branch branch = new Branch("b1", "Branch");


### PR DESCRIPTION
## Резюме
- уточнены описания @DisplayName для сценариев автодозвона, заменив терминологию на «режим автоматического вызова»
- скорректированы формулировки, чтобы подчеркнуть связь с автоматическим вызовом и избежать англицизмов

## Тестирование
- не запускалось (текстовые правки)


------
https://chatgpt.com/codex/tasks/task_e_68d63a1c227c8328bb5f3f1d88c4b768