### PR TITLE
Обновление описаний DisplayName в автотестах

### DIFF
--- a/src/test/unit/java/ru/aritmos/ApplicationConfigurerTest.java
+++ b/src/test/unit/java/ru/aritmos/ApplicationConfigurerTest.java
@@ -52,7 +52,7 @@ class ApplicationConfigurerTest {
         verifyNoMoreInteractions(builder);
     }
 
-    @DisplayName("Включает профиль infra по умолчанию при наличии удалённых сервисов")
+    @DisplayName("Включает профиль \"infra\" по умолчанию при наличии удалённых сервисов")
     @Test
     void enablesInfraByDefaultWhenRemoteEndpointsAvailable() {
         System.setProperty("redis.uri", "redis://example");
@@ -66,7 +66,7 @@ class ApplicationConfigurerTest {
         verifyNoMoreInteractions(builder);
     }
 
-    @DisplayName("Добавляет профиль infra к явно указанным окружениям")
+    @DisplayName("Добавляет профиль \"infra\" к явно указанным окружениям")
     @Test
     void appendsInfraWhenExplicitEnvironmentsProvided() {
         System.setProperty("micronaut.environments", "dev");

--- a/src/test/unit/java/ru/aritmos/clients/ConfigurationClientTest.java
+++ b/src/test/unit/java/ru/aritmos/clients/ConfigurationClientTest.java
@@ -19,7 +19,7 @@ class ConfigurationClientTest {
         assertEquals("${micronaut.application.configurationURL}", annotation.value());
     }
 
-    @DisplayName("Метод получения конфигурации объявлен с HTTP-методом GET")
+    @DisplayName("Метод получения конфигурации помечен HTTP-методом GET")
     @Test
     void getConfigurationMethodHasGetAnnotation() throws NoSuchMethodException {
         Method method = ConfigurationClient.class.getMethod("getConfiguration");

--- a/src/test/unit/java/ru/aritmos/config/SwaggerYamlCharsetFilterTest.java
+++ b/src/test/unit/java/ru/aritmos/config/SwaggerYamlCharsetFilterTest.java
@@ -27,7 +27,7 @@ class SwaggerYamlCharsetFilterTest {
     private static final Logger LOG = LoggerFactory.getLogger(SwaggerYamlCharsetFilterTest.class);
 
     @Test
-    @DisplayName("Добавление базового заголовка Content-Type для YAML без заголовка и логирование всех шагов")
+    @DisplayName("Фильтр добавляет заголовок Content-Type к YAML-ответу без указанного типа и протоколирует шаги")
     void addsDefaultYamlContentTypeWhenHeaderMissing() {
         LOG.info("Шаг 1: создаём ответ без заголовка Content-Type для YAML-спецификации.");
         MutableHttpResponse<?> response = HttpResponse.ok();
@@ -41,7 +41,7 @@ class SwaggerYamlCharsetFilterTest {
     }
 
     @Test
-    @DisplayName("Добавление кодировки UTF-8 к YAML-ответу без charset при обработке swagger-файла")
+    @DisplayName("Фильтр дописывает charset UTF-8 к YAML-ответу без кодировки при обработке swagger-файла")
 
     void appendsCharsetForYamlWithoutEncoding() {
         LOG.info("Шаг 1: подготавливаем ответ с типом application/yaml без charset.");
@@ -70,7 +70,7 @@ class SwaggerYamlCharsetFilterTest {
     }
 
     @Test
-    @DisplayName("Пропуск нерелевантных ответов: не-YAML содержимое и не-YAML запросы остаются неизменными")
+    @DisplayName("Фильтр пропускает нерелевантные ответы: не-YAML содержимое и запросы остаются без изменений")
 
     void skipsNonYamlResponsesAndRequests() {
         LOG.info("Шаг 1: ответ с типом application/json для запроса не к YAML-спецификации.");

--- a/src/test/unit/java/ru/aritmos/docs/CurlCheatsheetGeneratorTest.java
+++ b/src/test/unit/java/ru/aritmos/docs/CurlCheatsheetGeneratorTest.java
@@ -25,7 +25,7 @@ class CurlCheatsheetGeneratorTest {
      * Убеждаемся, что экранирование спецсимволов HTML работает корректно для угловых скобок и
      * амперсанда.
      */
-    @DisplayName("Экранирование HTML заменяет спецсимволы угловых скобок и амперсанда")
+    @DisplayName("Экранирование HTML заменяет символы угловых скобок и амперсанда")
     @Test
     void escapeHtml() throws Exception {
         Method escape = CurlCheatsheetGenerator.class.getDeclaredMethod("escape", String.class);
@@ -38,7 +38,7 @@ class CurlCheatsheetGeneratorTest {
      * Проверяет, что секция контроллера с комментариями «Пример curl» добавляется в итоговый HTML
      * и содержит исходный пример запроса.
      */
-    @DisplayName("Добавление секции контроллера переносит пример curl в HTML")
+    @DisplayName("Добавление секции контроллера переносит пример curl-запроса в HTML-вывод")
     @Test
     void appendControllerSectionAddsExample() throws Exception {
         Path file = Files.createTempFile("Controller", ".java");
@@ -69,7 +69,7 @@ class CurlCheatsheetGeneratorTest {
     /**
      * Убеждаемся, что главный метод создаёт HTML-файл со сведениями из контроллеров.
      */
-    @DisplayName("Главный метод генерирует HTML-шпаргалку по curl-запросам")
+    @DisplayName("Главный метод формирует HTML-шпаргалку с примерами curl-запросов")
     @Test
     void mainGeneratesCheatsheet() throws Exception {
         Path projectRoot = Paths.get("").toAbsolutePath();

--- a/src/test/unit/java/ru/aritmos/exceptions/BusinessExceptionLocalizationTest.java
+++ b/src/test/unit/java/ru/aritmos/exceptions/BusinessExceptionLocalizationTest.java
@@ -83,7 +83,7 @@ class BusinessExceptionLocalizationTest {
         assertEquals("Visit not found", appender.list.get(0).getFormattedMessage());
     }
 
-    @DisplayName("Заменяет поле «message» в теле ответа, представленном картой")
+    @DisplayName("Заменяет поле «message» в теле ответа, переданном в виде карты")
     @Test
     void replacesMessageFieldInMapResponseBody() {
         BusinessExceptionLocalizationProperties properties = new BusinessExceptionLocalizationProperties();

--- a/src/test/unit/java/ru/aritmos/handlers/EventHandlerContextTest.java
+++ b/src/test/unit/java/ru/aritmos/handlers/EventHandlerContextTest.java
@@ -30,7 +30,7 @@ class EventHandlerContextTest {
         Body(Branch branch) { this.b1 = branch; }
     }
 
-    @DisplayName("Обработчик BRANCH_PUBLIC преобразует тело события в карту")
+    @DisplayName("Обработчик с кодом BRANCH_PUBLIC преобразует тело события в карту")
     @Test
     void branchPublicHandlerConvertsBodyToMap() throws Exception {
         VisitService visitService = mock(VisitService.class);

--- a/src/test/unit/java/ru/aritmos/keycloack/model/KeyCloackUserTest.java
+++ b/src/test/unit/java/ru/aritmos/keycloack/model/KeyCloackUserTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 
 class KeyCloackUserTest {
 
-    @DisplayName("Модель пользователя Keycloak сохраняет и возвращает заданные поля")
+    @DisplayName("Модель пользователя Keycloak сохраняет и возвращает переданные поля")
     @Test
     void fieldsCanBeSetAndRead() {
         KeyCloackUser user = new KeyCloackUser();

--- a/src/test/unit/java/ru/aritmos/keycloack/service/EndSessionEndpointResolverReplacementTest.java
+++ b/src/test/unit/java/ru/aritmos/keycloack/service/EndSessionEndpointResolverReplacementTest.java
@@ -18,7 +18,7 @@ import org.mockito.Mockito;
 
 class EndSessionEndpointResolverReplacementTest {
 
-    @DisplayName("Метод resolve возвращает конечную точку сервиса Okta")
+    @DisplayName("Метод resolve возвращает конечную точку завершения сессии сервиса Okta")
     @Test
     void resolveReturnsOktaEndpoint() {
         BeanContext beanContext = Mockito.mock(BeanContext.class);

--- a/src/test/unit/java/ru/aritmos/keycloack/service/KeyCloackClientCoverageTest.java
+++ b/src/test/unit/java/ru/aritmos/keycloack/service/KeyCloackClientCoverageTest.java
@@ -159,7 +159,7 @@ class KeyCloackClientCoverageTest {
         assertTrue(result, "Ожидаем, что пользователь принадлежит типу admin");
     }
 
-    @DisplayName("Получение пользователя по SID возвращает данные при активной сессии")
+    @DisplayName("Получение пользователя по идентификатору SID возвращает данные при активной сессии")
     @Test
     void getUserBySidReturnsUserWhenSessionExists() {
         log.info("Готовим клиентов и сессии Keycloak для поиска пользователя по sid");

--- a/src/test/unit/java/ru/aritmos/model/EntityTest.java
+++ b/src/test/unit/java/ru/aritmos/model/EntityTest.java
@@ -21,7 +21,7 @@ class EntityTest {
     }
 
     @Test
-    @DisplayName("Методы доступа и equals/hashCode работают корректно")
+    @DisplayName("Методы доступа и пара equals/hashCode работают корректно")
     void gettersSettersAndEqualityWorkCorrectly() {
         Entity первый = new Entity();
         первый.setId("id-1");
@@ -37,7 +37,7 @@ class EntityTest {
     }
 
     @Test
-    @DisplayName("Класс Entity аннотирован Serdeable")
+    @DisplayName("Класс Entity помечен аннотацией Serdeable")
     void verifySerdeableAnnotation() {
         assertTrue(Entity.class.isAnnotationPresent(Serdeable.class));
     }

--- a/src/test/unit/java/ru/aritmos/model/GroovyScriptTest.java
+++ b/src/test/unit/java/ru/aritmos/model/GroovyScriptTest.java
@@ -47,7 +47,7 @@ class GroovyScriptTest {
     }
 
     @Test
-    @DisplayName("Модель GroovyScript помечена Serdeable и использует JsonInclude.ALWAYS для карт")
+    @DisplayName("Модель GroovyScript помечена аннотацией Serdeable и использует JsonInclude.ALWAYS для карт")
     void verifiesAnnotations() throws NoSuchFieldException {
         assertTrue(GroovyScript.class.isAnnotationPresent(Serdeable.class));
 

--- a/src/test/unit/java/ru/aritmos/model/visit/VisitStateTest.java
+++ b/src/test/unit/java/ru/aritmos/model/visit/VisitStateTest.java
@@ -30,7 +30,7 @@ class VisitStateTest {
     }
 
     @Test
-    @DisplayName("Перечисление состояний визита аннотировано Serdeable")
+    @DisplayName("Перечисление состояний визита помечено аннотацией Serdeable")
     void verifySerdeableAnnotation() {
         assertTrue(VisitState.class.isAnnotationPresent(Serdeable.class));
     }

--- a/src/test/unit/java/ru/aritmos/service/BranchServiceTest.java
+++ b/src/test/unit/java/ru/aritmos/service/BranchServiceTest.java
@@ -629,7 +629,7 @@ class BranchServiceTest {
     /**
      * Подгружает профиль сотрудника из Keycloak при первом открытии точки.
      */
-    @DisplayName("Открытие точки обслуживания обновляет пользователя из Keycloak")
+    @DisplayName("Открытие точки обслуживания подтягивает данные сотрудника из Keycloak")
     @Test
     void openServicePointUpdatesUserFromKeycloak() throws Exception {
         BranchService service = new BranchService();

--- a/src/test/unit/java/ru/aritmos/service/VisitServiceCreateVirtualVisit2Test.java
+++ b/src/test/unit/java/ru/aritmos/service/VisitServiceCreateVirtualVisit2Test.java
@@ -140,7 +140,7 @@ class VisitServiceCreateVirtualVisit2Test {
         assertEquals(staff.getName(), startServing.getParameters().get("staffName"));
     }
 
-    @DisplayName("Создание виртуального визита использует данные Keycloak при отсутствии пользователя у точки")
+    @DisplayName("Создание виртуального визита подставляет данные из Keycloak при отсутствии оператора у точки")
     @Test
     void createVirtualVisit2UsesKeycloakDataWhenServicePointWithoutUser() throws SystemException {
         Branch branch = new Branch("b2", "Отделение №2");

--- a/src/test/unit/java/ru/aritmos/service/VisitServiceTest.java
+++ b/src/test/unit/java/ru/aritmos/service/VisitServiceTest.java
@@ -466,7 +466,7 @@ class VisitServiceTest {
         assertTrue(result.containsKey("sp2"));
     }
 
-    @DisplayName("Получение рабочих профилей возвращает Tiny-модели")
+    @DisplayName("Получение рабочих профилей возвращает упрощённые модели Tiny")
     @Test
     void getWorkProfilesReturnsTinyClasses() {
         Branch branch = new Branch("b1", "Branch");

--- a/src/test/unit/java/ru/aritmos/service/VisitServiceTransferFromQueueTest.java
+++ b/src/test/unit/java/ru/aritmos/service/VisitServiceTransferFromQueueTest.java
@@ -203,7 +203,7 @@ class VisitServiceTransferFromQueueTest {
         assertEquals(visit.getTicket(), body.get("ticket"));
     }
 
-    @DisplayName("Перенос визита во внешнюю очередь передаёт данные услуги и идентификатор SID")
+    @DisplayName("Перенос визита во внешнюю очередь сохраняет данные услуги и идентификатор SID")
     @Test
     void visitTransferToQueueFromExternalServicePropagatesServiceInfoAndSid() {
         log.info("Готовим отделение с очередями и заполняем информацию Keycloak");

--- a/src/test/unit/java/ru/aritmos/service/VisitServiceVisitConfirmTest.java
+++ b/src/test/unit/java/ru/aritmos/service/VisitServiceVisitConfirmTest.java
@@ -42,7 +42,7 @@ class VisitServiceVisitConfirmTest {
         VisitEvent.START_SERVING.getParameters().clear();
     }
 
-    @DisplayName("Подтверждение визита переводит клиента к точке обслуживания и публикует событие START_SERVING")
+    @DisplayName("Подтверждение визита переводит клиента к точке обслуживания и публикует событие со статусом START_SERVING")
     @Test
     void visitConfirmMovesVisitToServicePointAndPublishesStartServingEvent() {
         log.info("Готовим отделение и точку обслуживания для позитивного сценария подтверждения визита");

--- a/src/test/unit/java/ru/aritmos/service/rules/CallRuleTest.java
+++ b/src/test/unit/java/ru/aritmos/service/rules/CallRuleTest.java
@@ -21,7 +21,7 @@ class CallRuleTest {
         assertTrue(Rule.class.isAssignableFrom(CallRule.class));
     }
 
-    @DisplayName("Метод вызова без фильтра очередей возвращает Optional с визитом")
+    @DisplayName("Метод вызова без фильтра очередей возвращает визит в контейнере Optional")
     @Test
     void callMethodWithoutQueueFilterShouldReturnOptionalVisit() throws NoSuchMethodException {
         Method method = CallRule.class.getMethod("call", Branch.class, ServicePoint.class);
@@ -32,7 +32,7 @@ class CallRuleTest {
         assertEquals(Visit.class, elementType);
     }
 
-    @DisplayName("Метод вызова с фильтром очередей возвращает Optional с визитом")
+    @DisplayName("Метод вызова с фильтром очередей возвращает визит в контейнере Optional")
     @Test
     void callMethodWithQueueFilterShouldReturnOptionalVisit() throws NoSuchMethodException {
         Method method = CallRule.class.getMethod("call", Branch.class, ServicePoint.class, List.class);


### PR DESCRIPTION
## Summary
- уточнил формулировки @DisplayName в тестах ApplicationConfigurer, генератора curl и фильтра Swagger, убрав смешение языков
- скорректировал описания сценариев работы с Keycloak, SID и Tiny-моделями в сервисных тестах
- привёл формулировки других тестов к единообразной русскоязычной терминологии (Optional, START_SERVING, BRANCH_PUBLIC)

## Testing
- not run (только правки описаний тестов)


------
https://chatgpt.com/codex/tasks/task_e_68d63cc5835c8328881bd51ac4b9fc69