### PR TITLE
Устраняю предупреждения тестов и обновляю конфигурацию Surefire

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -392,24 +392,30 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.5.3</version>
-                <configuration>
-                    <argLine>${argLine}
-                        -javaagent:${settings.localRepository}/org/mockito/mockito-core/${mockito.version}/mockito-core-${mockito.version}.jar
-                        -XX:+EnableDynamicAgentLoading -Xshare:off
-                    </argLine>
-                    <excludes>
-                        <exclude>**/*IT.java</exclude>
-                    </excludes>
-                    <systemPropertyVariables>
-                        <micronaut.environments>${tests.micronaut.environments}</micronaut.environments>
-                        <micronaut.test.resources.enabled>${micronaut.test.resources.enabled}
-                        </micronaut.test.resources.enabled>
-                        <junit.platform.listeners.uid.tracking.enabled>true
-                        </junit.platform.listeners.uid.tracking.enabled>
-                        <junit.platform.listeners.uid.tracking.output.dir>${project.build.directory}/test-ids
-                        </junit.platform.listeners.uid.tracking.output.dir>
-                    </systemPropertyVariables>
-                </configuration>
+                <executions combine.self="override">
+                    <execution>
+                        <id>default-test</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration combine.self="override">
+                            <argLine>${argLine}
+                                -javaagent:${settings.localRepository}/org/mockito/mockito-core/${mockito.version}/mockito-core-${mockito.version}.jar
+                                -XX:+EnableDynamicAgentLoading -Xshare:off
+                            </argLine>
+                            <excludes>
+                                <exclude>**/*IT.java</exclude>
+                            </excludes>
+                            <systemPropertyVariables>
+                                <micronaut.environments>${tests.micronaut.environments}</micronaut.environments>
+                                <micronaut.test.resources.enabled>${micronaut.test.resources.enabled}</micronaut.test.resources.enabled>
+                                <junit.platform.listeners.uid.tracking.enabled>true</junit.platform.listeners.uid.tracking.enabled>
+                                <junit.platform.listeners.uid.tracking.output.dir>${project.build.directory}/test-ids</junit.platform.listeners.uid.tracking.output.dir>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
 
             <plugin>

--- a/src/test/integration/java/ru/aritmos/integration/KeycloakKafkaIntegrationIT.java
+++ b/src/test/integration/java/ru/aritmos/integration/KeycloakKafkaIntegrationIT.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.DockerClientFactory;
-import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.kafka.KafkaContainer;
 import org.testcontainers.utility.DockerImageName;
 
 /**

--- a/src/test/unit/java/ru/aritmos/api/ServicePointControllerVisitTransferTest.java
+++ b/src/test/unit/java/ru/aritmos/api/ServicePointControllerVisitTransferTest.java
@@ -7,6 +7,7 @@ import static ru.aritmos.test.LoggingAssertions.*;
 import io.micronaut.http.HttpStatus;
 import io.micronaut.http.exceptions.HttpStatusException;
 import java.util.HashMap;
+import org.mockito.ArgumentMatchers;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -256,9 +257,9 @@ class ServicePointControllerVisitTransferTest {
                 anyString(),
                 any(Visit.class),
                 anyBoolean(),
-                any(HashMap.class),
+                ArgumentMatchers.<HashMap<String, String>>any(),
                 anyLong(),
-                any()
+                anyString()
             )
         ).thenReturn(response);
 
@@ -311,9 +312,9 @@ class ServicePointControllerVisitTransferTest {
                 anyString(),
                 any(Visit.class),
                 anyBoolean(),
-                any(HashMap.class),
+                ArgumentMatchers.<HashMap<String, String>>any(),
                 anyLong(),
-                any()
+                anyString()
             )
         ).thenReturn(response);
 


### PR DESCRIPTION
## Summary
- перевёл интеграционный тест KeycloakKafkaIntegrationIT на современный org.testcontainers.kafka.KafkaContainer
- зафиксировал типизированные матчеры Mockito в ServicePointControllerVisitTransferTest, устранив предупреждения о небезопасных операциях
- перенастроил maven-surefire-plugin 3.5.3 на systemPropertyVariables, сохранив javaagent и исключения интеграционных тестов без устаревших параметров

## Testing
- `mvn -s .mvn/settings.xml -Dmaven.compiler.showWarnings=true -Dmaven.compiler.showDeprecation=true test`


------
https://chatgpt.com/codex/tasks/task_e_68d66a3c02d48328b07d7f40e41569ce