### PR TITLE
docs: уточнить openapi и javadoc контроллеров

### DIFF
--- a/src/main/java/ru/aritmos/api/ConfigurationController.java
+++ b/src/main/java/ru/aritmos/api/ConfigurationController.java
@@ -4,6 +4,8 @@ import groovy.util.logging.Slf4j;
 import io.micronaut.http.HttpStatus;
 import io.micronaut.http.annotation.*;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -55,10 +57,21 @@ public class ConfigurationController {
   @Tag(name = "Конфигурация отделений")
   @Tag(name = "Полный список")
   @Operation(
+      operationId = "updateBranchConfiguration",
       summary = "Обновление конфигурации отделений",
       description = "Создает или обновляет конфигурацию отделений",
       responses = {
-        @ApiResponse(responseCode = "200", description = "Конфигурация обновлена"),
+        @ApiResponse(
+            responseCode = "200",
+            description = "Конфигурация обновлена",
+            content =
+                @Content(
+                    mediaType = "application/json",
+                    schema =
+                        @Schema(
+                            type = "object",
+                            additionalProperties =
+                                @Schema(implementation = Branch.class)))),
         @ApiResponse(responseCode = "400", description = "Некорректный запрос"),
         @ApiResponse(responseCode = "500", description = "Ошибка сервера")
       })
@@ -75,10 +88,21 @@ public class ConfigurationController {
   @Tag(name = "Конфигурация отделений")
   @Tag(name = "Полный список")
   @Operation(
+      operationId = "publishDemoConfiguration",
       summary = "Обновление демо-конфигурации отделений",
       description = "Создает конфигурацию отделений на основе демо-данных",
       responses = {
-        @ApiResponse(responseCode = "200", description = "Конфигурация обновлена"),
+        @ApiResponse(
+            responseCode = "200",
+            description = "Конфигурация обновлена",
+            content =
+                @Content(
+                    mediaType = "application/json",
+                    schema =
+                        @Schema(
+                            type = "object",
+                            additionalProperties =
+                                @Schema(implementation = Branch.class)))),
         @ApiResponse(responseCode = "400", description = "Некорректный запрос"),
         @ApiResponse(responseCode = "500", description = "Ошибка сервера")
       })
@@ -98,6 +122,7 @@ public class ConfigurationController {
   @Tag(name = "Конфигурация отделений (в разработке!)")
   @Tag(name = "Полный список")
   @Operation(
+      operationId = "addOrUpdateServices",
       summary = "Добавление или обновление услуг",
       description = "Создает или изменяет услуги отделения",
       responses = {
@@ -123,10 +148,20 @@ public class ConfigurationController {
   @Tag(name = "Перерывы")
   @Tag(name = "Полный список")
   @Operation(
+      operationId = "getBreakReasons",
       summary = "Получение списка причин перерыва",
       description = "Возвращает перечень причин перерыва для отделения",
       responses = {
-        @ApiResponse(responseCode = "200", description = "Список причин перерыва"),
+        @ApiResponse(
+            responseCode = "200",
+            description = "Список причин перерыва",
+            content =
+                @Content(
+                    mediaType = "application/json",
+                    schema =
+                        @Schema(
+                            type = "object",
+                            additionalProperties = @Schema(implementation = String.class)))),
         @ApiResponse(responseCode = "404", description = "Отделение не найдено"),
         @ApiResponse(responseCode = "500", description = "Ошибка сервера")
       })
@@ -146,6 +181,7 @@ public class ConfigurationController {
   @Tag(name = "Конфигурация отделений (в разработке!)")
   @Tag(name = "Полный список")
   @Operation(
+      operationId = "deleteServices",
       summary = "Удаление услуг",
       description = "Удаляет услуги отделения",
       responses = {

--- a/src/main/java/ru/aritmos/api/KeyCloakController.java
+++ b/src/main/java/ru/aritmos/api/KeyCloakController.java
@@ -5,7 +5,9 @@ import io.micronaut.http.annotation.*;
 import io.micronaut.serde.annotation.SerdeImport;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -66,6 +68,7 @@ public class KeyCloakController {
    * @return ответ авторизации с набором токенов
    */
   @Operation(
+      operationId = "authorizeInKeycloak",
       summary = "Авторизация пользователя в Keycloak",
       description = "Возвращает токены авторизации при корректных учётных данных",
       responses = {
@@ -82,7 +85,22 @@ public class KeyCloakController {
   @Tag(name = "Полный список")
   @Tag(name = "Взаимодействие с Keycloak")
   @Post(uri = "/keycloak", consumes = "application/json", produces = "application/json")
-  Optional<AuthorizationResponse> Auth(@Body Credentials credentials) {
+  Optional<AuthorizationResponse> Auth(
+      @Body
+          @RequestBody(
+              description = "Учетные данные пользователя для авторизации",
+              required = true,
+              content =
+                  @Content(
+                      mediaType = "application/json",
+                      schema = @Schema(implementation = Credentials.class),
+                      examples =
+                          @ExampleObject(
+                              name = "staffCredentials",
+                              summary = "Пример логина сотрудника",
+                              value =
+                                  "{\n  \"username\": \"operator\",\n  \"password\": \"p@ssw0rd\"\n}")))
+          Credentials credentials) {
     return keyCloackClient.Auth(credentials);
   }
 
@@ -94,6 +112,7 @@ public class KeyCloakController {
    * @param reason причина завершения
    */
   @Operation(
+      operationId = "logoutUserSession",
       summary = "Завершение пользовательской сессии",
       description = "Удаляет активную сессию пользователя в Keycloak",
       responses = {

--- a/src/main/java/ru/aritmos/api/ManagementController.java
+++ b/src/main/java/ru/aritmos/api/ManagementController.java
@@ -5,6 +5,7 @@ import io.micronaut.http.annotation.*;
 import io.micronaut.scheduling.TaskExecutors;
 import io.micronaut.scheduling.annotation.ExecuteOn;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -51,6 +52,7 @@ public class ManagementController {
    * @return состояние отделения
    */
   @Operation(
+      operationId = "getBranch",
       summary = "Получение состояния отделения",
       description = "Возвращает подробную информацию об отделении по его идентификатору",
       responses = {
@@ -82,11 +84,22 @@ public class ManagementController {
   @Tag(name = "Информация об отделении")
   @Tag(name = "Полный список")
   @Operation(
+      operationId = "getBranches",
       summary = "Получение списка отделений",
       description =
           "Возвращает карту доступных отделений. При передаче имени пользователя список ограничивается его филиалами",
       responses = {
-        @ApiResponse(responseCode = "200", description = "Список отделений"),
+        @ApiResponse(
+            responseCode = "200",
+            description = "Список отделений",
+            content =
+                @Content(
+                    mediaType = "application/json",
+                    schema =
+                        @Schema(
+                            type = "object",
+                            additionalProperties =
+                                @Schema(implementation = Branch.class)))),
         @ApiResponse(responseCode = "400", description = "Некорректный запрос"),
         @ApiResponse(responseCode = "500", description = "Ошибка сервера")
       })
@@ -130,10 +143,17 @@ public class ManagementController {
   @Tag(name = "Информация об отделении")
   @Tag(name = "Полный список")
   @Operation(
+      operationId = "getTinyBranches",
       summary = "Минимальная информация об отделениях",
       description = "Возвращает идентификаторы и названия отделений",
       responses = {
-        @ApiResponse(responseCode = "200", description = "Список отделений"),
+        @ApiResponse(
+            responseCode = "200",
+            description = "Список отделений",
+            content =
+                @Content(
+                    mediaType = "application/json",
+                    array = @ArraySchema(schema = @Schema(implementation = TinyClass.class)))),
         @ApiResponse(responseCode = "400", description = "Некорректный запрос"),
         @ApiResponse(responseCode = "500", description = "Ошибка сервера")
       })


### PR DESCRIPTION
## Summary
- уточнил openapi-аннотации конфигурационных эндпоинтов, добавив operationId и схемы ответов
- дополнил management API сведениями о схемах выдачи отделений для openapi
- расширил описание авторизации в Keycloak примерами тела запроса

## Testing
- `mvn -s .mvn/settings.xml -DskipTests -Ddoclint=all -DfailOnWarnings=true javadoc:javadoc`


------
https://chatgpt.com/codex/tasks/task_e_68d68a84c8b083288d195af8ec02bfa0