### PR TITLE
Fix OpenAPI schema definitions for map responses

### DIFF
--- a/src/main/java/ru/aritmos/api/ConfigurationController.java
+++ b/src/main/java/ru/aritmos/api/ConfigurationController.java
@@ -70,8 +70,7 @@ public class ConfigurationController {
                     schema =
                         @Schema(
                             type = "object",
-                            additionalProperties =
-                                @Schema(implementation = Branch.class)))),
+                            additionalPropertiesSchema = Branch.class))),
         @ApiResponse(responseCode = "400", description = "Некорректный запрос"),
         @ApiResponse(responseCode = "500", description = "Ошибка сервера")
       })
@@ -101,8 +100,7 @@ public class ConfigurationController {
                     schema =
                         @Schema(
                             type = "object",
-                            additionalProperties =
-                                @Schema(implementation = Branch.class)))),
+                            additionalPropertiesSchema = Branch.class))),
         @ApiResponse(responseCode = "400", description = "Некорректный запрос"),
         @ApiResponse(responseCode = "500", description = "Ошибка сервера")
       })
@@ -161,7 +159,7 @@ public class ConfigurationController {
                     schema =
                         @Schema(
                             type = "object",
-                            additionalProperties = @Schema(implementation = String.class)))),
+                            additionalPropertiesSchema = String.class))),
         @ApiResponse(responseCode = "404", description = "Отделение не найдено"),
         @ApiResponse(responseCode = "500", description = "Ошибка сервера")
       })

--- a/src/main/java/ru/aritmos/api/ManagementController.java
+++ b/src/main/java/ru/aritmos/api/ManagementController.java
@@ -98,8 +98,7 @@ public class ManagementController {
                     schema =
                         @Schema(
                             type = "object",
-                            additionalProperties =
-                                @Schema(implementation = Branch.class)))),
+                            additionalPropertiesSchema = Branch.class))),
         @ApiResponse(responseCode = "400", description = "Некорректный запрос"),
         @ApiResponse(responseCode = "500", description = "Ошибка сервера")
       })


### PR DESCRIPTION
## Summary
- replace invalid additionalProperties annotations in ConfigurationController with valid references to Branch and String classes
- update ManagementController to use proper additionalProperties schema for branch map response
- run Maven build to confirm compilation succeeds

## Testing
- mvn -s .mvn/settings.xml -DskipTests clean compile

------
https://chatgpt.com/codex/tasks/task_e_68d69076f1a48328a9a94748ac185046