### PR TITLE
fix: align Netty dependencies with Micronaut requirements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,18 +117,18 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId>
-            <version>4.1.119.Final</version>
+            <version>4.2.4.Final</version>
         </dependency>
 
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-common</artifactId>
-            <version>4.1.119.Final</version>
+            <version>4.2.4.Final</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-handler</artifactId>
-            <version>4.1.119.Final</version>
+            <version>4.2.4.Final</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.keycloak/keycloak-authz-client -->
 


### PR DESCRIPTION
## Summary
- обновил зависимости io.netty до версии 4.2.4.Final, чтобы предоставить класс `ThreadAwareExecutor`, требуемый Micronaut при создании `EventLoopGroup`

## Testing
- mvn -s .mvn/settings.xml clean verify

------
https://chatgpt.com/codex/tasks/task_e_68d6be89c220832883bb0e32689ef74f